### PR TITLE
Extend repo layer with queryable methods and new repositories

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -1,0 +1,6 @@
+# Project Log
+
+## [repo_agent] Extend repositories
+- Added queryable and conditional fetch methods with cancellation token support
+- Added patch method for partial updates
+- Implemented repository interfaces and EF Core classes for Supplier, TaxRate, PaymentMethod, Unit, and ProductGroup

--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -7,3 +7,5 @@ Created initial domain entity classes under `Domain/Entities`.
 
 ## [repo_agent] Implement EF Core repositories
 Created base repository abstractions and EF Core implementations for Invoice and Product entities under `Repositories/`.
+## [repo_agent] Extend repositories with querying and patch support
+Added AsQueryable, GetByConditionAsync, PatchAsync to base repository and interfaces. Implemented repositories for Supplier, TaxRate, PaymentMethod, Unit, ProductGroup.

--- a/Repositories/BaseRepository.cs
+++ b/Repositories/BaseRepository.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -18,6 +21,11 @@ namespace Facturon.Repositories
             _dbSet = _context.Set<TEntity>();
         }
 
+        public virtual IQueryable<TEntity> AsQueryable()
+        {
+            return _dbSet.AsQueryable();
+        }
+
         public virtual async Task<TEntity?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
         {
             return await _dbSet.AsNoTracking().FirstOrDefaultAsync(e => e.Id == id, cancellationToken);
@@ -28,6 +36,15 @@ namespace Facturon.Repositories
             return await _dbSet.AsNoTracking().ToListAsync(cancellationToken);
         }
 
+        public virtual async Task<List<TEntity>> GetByConditionAsync(
+            Expression<Func<TEntity, bool>> filter,
+            CancellationToken cancellationToken = default)
+        {
+            return await _dbSet.AsNoTracking()
+                .Where(filter)
+                .ToListAsync(cancellationToken);
+        }
+
         public virtual async Task AddAsync(TEntity entity, CancellationToken cancellationToken = default)
         {
             await _dbSet.AddAsync(entity, cancellationToken);
@@ -36,6 +53,16 @@ namespace Facturon.Repositories
 
         public virtual async Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
         {
+            _dbSet.Update(entity);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        public virtual async Task PatchAsync(int id, Action<TEntity> patchAction, CancellationToken cancellationToken = default)
+        {
+            var entity = await _dbSet.FindAsync(new object?[] { id }, cancellationToken);
+            if (entity == null) return;
+
+            patchAction(entity);
             _dbSet.Update(entity);
             await _context.SaveChangesAsync(cancellationToken);
         }

--- a/Repositories/EfPaymentMethodRepository.cs
+++ b/Repositories/EfPaymentMethodRepository.cs
@@ -1,0 +1,12 @@
+using Facturon.Data;
+using Facturon.Domain.Entities;
+
+namespace Facturon.Repositories
+{
+    public class EfPaymentMethodRepository : BaseRepository<PaymentMethod>, IPaymentMethodRepository
+    {
+        public EfPaymentMethodRepository(FacturonDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Repositories/EfProductGroupRepository.cs
+++ b/Repositories/EfProductGroupRepository.cs
@@ -1,0 +1,12 @@
+using Facturon.Data;
+using Facturon.Domain.Entities;
+
+namespace Facturon.Repositories
+{
+    public class EfProductGroupRepository : BaseRepository<ProductGroup>, IProductGroupRepository
+    {
+        public EfProductGroupRepository(FacturonDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Repositories/EfSupplierRepository.cs
+++ b/Repositories/EfSupplierRepository.cs
@@ -1,0 +1,12 @@
+using Facturon.Data;
+using Facturon.Domain.Entities;
+
+namespace Facturon.Repositories
+{
+    public class EfSupplierRepository : BaseRepository<Supplier>, ISupplierRepository
+    {
+        public EfSupplierRepository(FacturonDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Repositories/EfTaxRateRepository.cs
+++ b/Repositories/EfTaxRateRepository.cs
@@ -1,0 +1,12 @@
+using Facturon.Data;
+using Facturon.Domain.Entities;
+
+namespace Facturon.Repositories
+{
+    public class EfTaxRateRepository : BaseRepository<TaxRate>, ITaxRateRepository
+    {
+        public EfTaxRateRepository(FacturonDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Repositories/EfUnitRepository.cs
+++ b/Repositories/EfUnitRepository.cs
@@ -1,0 +1,12 @@
+using Facturon.Data;
+using Facturon.Domain.Entities;
+
+namespace Facturon.Repositories
+{
+    public class EfUnitRepository : BaseRepository<Unit>, IUnitRepository
+    {
+        public EfUnitRepository(FacturonDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Repositories/IBaseRepository.cs
+++ b/Repositories/IBaseRepository.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Facturon.Domain.Entities;
@@ -7,10 +10,21 @@ namespace Facturon.Repositories
 {
     public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     {
+        IQueryable<TEntity> AsQueryable();
+
         Task<TEntity?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
         Task<List<TEntity>> GetAllAsync(CancellationToken cancellationToken = default);
+
+        Task<List<TEntity>> GetByConditionAsync(Expression<Func<TEntity, bool>> filter,
+            CancellationToken cancellationToken = default);
+
         Task AddAsync(TEntity entity, CancellationToken cancellationToken = default);
+
         Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default);
+
+        Task PatchAsync(int id, Action<TEntity> patchAction, CancellationToken cancellationToken = default);
+
         Task DeleteAsync(int id, CancellationToken cancellationToken = default);
     }
 }

--- a/Repositories/IPaymentMethodRepository.cs
+++ b/Repositories/IPaymentMethodRepository.cs
@@ -1,0 +1,8 @@
+using Facturon.Domain.Entities;
+
+namespace Facturon.Repositories
+{
+    public interface IPaymentMethodRepository : IBaseRepository<PaymentMethod>
+    {
+    }
+}

--- a/Repositories/IProductGroupRepository.cs
+++ b/Repositories/IProductGroupRepository.cs
@@ -1,0 +1,8 @@
+using Facturon.Domain.Entities;
+
+namespace Facturon.Repositories
+{
+    public interface IProductGroupRepository : IBaseRepository<ProductGroup>
+    {
+    }
+}

--- a/Repositories/ISupplierRepository.cs
+++ b/Repositories/ISupplierRepository.cs
@@ -1,0 +1,8 @@
+using Facturon.Domain.Entities;
+
+namespace Facturon.Repositories
+{
+    public interface ISupplierRepository : IBaseRepository<Supplier>
+    {
+    }
+}

--- a/Repositories/ITaxRateRepository.cs
+++ b/Repositories/ITaxRateRepository.cs
@@ -1,0 +1,8 @@
+using Facturon.Domain.Entities;
+
+namespace Facturon.Repositories
+{
+    public interface ITaxRateRepository : IBaseRepository<TaxRate>
+    {
+    }
+}

--- a/Repositories/IUnitRepository.cs
+++ b/Repositories/IUnitRepository.cs
@@ -1,0 +1,8 @@
+using Facturon.Domain.Entities;
+
+namespace Facturon.Repositories
+{
+    public interface IUnitRepository : IBaseRepository<Unit>
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- expose `AsQueryable`/`GetByConditionAsync` in `BaseRepository`
- add `PatchAsync` for partial updates
- implement repository interfaces and EF Core repos for Supplier, TaxRate, PaymentMethod, Unit and ProductGroup
- log repository changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ea5f51fa08322bc9290d8f7190328