### PR TITLE
Fix LINQ extension usage in ProductService

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -34,3 +34,6 @@ enable `UseSqlite` configuration.
 Added metadata builder using statement to FacturonDbContext to resolve extension methods.
 ## [orchestrator_agent] Add root solution
 Created Facturon.sln including all projects for easier IDE use.
+
+## [service_agent] Fix missing System.Linq using
+Added missing using directive in ProductService for LINQ extension methods.

--- a/Services/ProductService.cs
+++ b/Services/ProductService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Facturon.Domain.Entities;
 using Facturon.Repositories;


### PR DESCRIPTION
## Summary
- add missing `System.Linq` namespace usage in `ProductService`
- record the fix in `PROMPT_LOG.md`

## Testing
- `N/A` (build commands unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_687eb9a0ce1c8322b6e8f24933ffa1c1