### PR TITLE
Fix startup build errors

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -37,3 +37,5 @@ Created Facturon.sln including all projects for easier IDE use.
 
 ## [service_agent] Fix missing System.Linq using
 Added missing using directive in ProductService for LINQ extension methods.
+## [startup_agent] Resolve missing host and logging references
+Added Microsoft.Extensions.Hosting and Serilog packages to the startup project and updated App.xaml.cs null checks.

--- a/Startup/App.xaml.cs
+++ b/Startup/App.xaml.cs
@@ -11,17 +11,19 @@ namespace Facturon.App
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
-            if (Host != null)
+            var host = Host;
+            if (host != null)
             {
-                StartupOrchestrator.Start(Host);
+                StartupOrchestrator.Start(host);
             }
         }
 
         protected override void OnExit(ExitEventArgs e)
         {
-            if (Host != null)
+            var host = Host;
+            if (host != null)
             {
-                StartupOrchestrator.StopAsync(Host).GetAwaiter().GetResult();
+                StartupOrchestrator.StopAsync(host).GetAwaiter().GetResult();
             }
             base.OnExit(e);
         }

--- a/Startup/Facturon.App.csproj
+++ b/Startup/Facturon.App.csproj
@@ -11,5 +11,10 @@
     <ProjectReference Include="..\Repositories\Facturon.Repositories.csproj" />
     <ProjectReference Include="..\Services\Facturon.Services.csproj" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.5.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add missing Microsoft.Extensions.Hosting and Serilog packages to startup project
- guard host usage using local variables in App.xaml.cs
- log the change in PROMPT_LOG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ebb0c2e0c832294aef81fe32e743f