### PR TITLE
Add WPF MVVM UI layer

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -42,3 +42,5 @@ Added Microsoft.Extensions.Hosting and Serilog packages to the startup project a
 
 ## [startup_agent] Fix build entry point and Serilog warning
 Removed Program.cs to avoid duplicate entry points and moved host initialization to App.xaml.cs. Updated Serilog.Settings.Configuration to version 7.0.0.
+## [ui_agent] Implement initial WPF MVVM UI
+Added views, view models, and startup wiring for keyboard-first invoice UI.

--- a/Startup/App.xaml
+++ b/Startup/App.xaml
@@ -1,4 +1,11 @@
 <Application x:Class="Facturon.App.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Themes/LightTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
 </Application>

--- a/Startup/App.xaml.cs
+++ b/Startup/App.xaml.cs
@@ -1,6 +1,10 @@
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Facturon.App.Views;
+using Facturon.App.ViewModels;
+using Facturon.Services;
 
 namespace Facturon.App
 {
@@ -14,6 +18,13 @@ namespace Facturon.App
 
             Host = StartupOrchestrator.BuildHost(e.Args);
             StartupOrchestrator.Start(Host);
+
+            var invoiceService = Host.Services.GetRequiredService<IInvoiceService>();
+            var vm = new MainViewModel(invoiceService);
+            vm.InitializeAsync().GetAwaiter().GetResult();
+            var window = new MainWindow { DataContext = vm };
+            MainWindow = window;
+            window.Show();
         }
 
         protected override void OnExit(ExitEventArgs e)

--- a/Startup/Facturon.App.csproj
+++ b/Startup/Facturon.App.csproj
@@ -16,5 +16,8 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-  </ItemGroup>
+    <Compile Include="..\ViewModels\**\*.cs" />
+    <Page Include="..\Views\**\*.xaml" />
+    <Page Include="..\Themes\**\*.xaml" />
+</ItemGroup>
 </Project>

--- a/Themes/LightTheme.xaml
+++ b/Themes/LightTheme.xaml
@@ -1,0 +1,4 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="WindowBackground" Color="White" />
+</ResourceDictionary>

--- a/ViewModels/BaseViewModel.cs
+++ b/ViewModels/BaseViewModel.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Facturon.App.ViewModels
+{
+    public abstract class BaseViewModel : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -1,0 +1,21 @@
+using Facturon.Domain.Entities;
+
+namespace Facturon.App.ViewModels
+{
+    public class InvoiceDetailViewModel : BaseViewModel
+    {
+        private Invoice? _invoice;
+        public Invoice? Invoice
+        {
+            get => _invoice;
+            set
+            {
+                if (_invoice != value)
+                {
+                    _invoice = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+    }
+}

--- a/ViewModels/InvoiceListViewModel.cs
+++ b/ViewModels/InvoiceListViewModel.cs
@@ -1,0 +1,42 @@
+using System.Collections.ObjectModel;
+using Facturon.Domain.Entities;
+using Facturon.Services;
+
+namespace Facturon.App.ViewModels
+{
+    public class InvoiceListViewModel : BaseViewModel
+    {
+        private readonly IInvoiceService _invoiceService;
+
+        public ObservableCollection<Invoice> Invoices { get; } = new();
+
+        private Invoice? _selectedInvoice;
+        public Invoice? SelectedInvoice
+        {
+            get => _selectedInvoice;
+            set
+            {
+                if (_selectedInvoice != value)
+                {
+                    _selectedInvoice = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public InvoiceListViewModel(IInvoiceService invoiceService)
+        {
+            _invoiceService = invoiceService;
+        }
+
+        public async Task LoadAsync()
+        {
+            Invoices.Clear();
+            var list = await _invoiceService.GetAllAsync();
+            foreach (var invoice in list)
+            {
+                Invoices.Add(invoice);
+            }
+        }
+    }
+}

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,0 +1,93 @@
+using Facturon.Services;
+
+namespace Facturon.App.ViewModels
+{
+    public class MainViewModel : BaseViewModel
+    {
+        private readonly IInvoiceService _invoiceService;
+
+        public InvoiceListViewModel InvoiceList { get; }
+        public InvoiceDetailViewModel InvoiceDetail { get; } = new();
+
+        private bool _detailVisible;
+        public bool DetailVisible
+        {
+            get => _detailVisible;
+            set
+            {
+                if (_detailVisible != value)
+                {
+                    _detailVisible = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public RelayCommand OpenInvoiceCommand { get; }
+        public RelayCommand CloseDetailCommand { get; }
+        public RelayCommand NewInvoiceCommand { get; }
+        public RelayCommand DeleteInvoiceCommand { get; }
+
+        public MainViewModel(IInvoiceService invoiceService)
+        {
+            _invoiceService = invoiceService;
+            InvoiceList = new InvoiceListViewModel(invoiceService);
+
+            OpenInvoiceCommand = new RelayCommand(OpenSelected, CanOpenSelected);
+            CloseDetailCommand = new RelayCommand(CloseDetail, () => DetailVisible);
+            NewInvoiceCommand = new RelayCommand(NewInvoice);
+            DeleteInvoiceCommand = new RelayCommand(DeleteSelected, CanDeleteSelected);
+        }
+
+        public async Task InitializeAsync()
+        {
+            await InvoiceList.LoadAsync();
+        }
+
+        private bool CanOpenSelected() => InvoiceList.SelectedInvoice != null;
+
+        private void OpenSelected()
+        {
+            if (InvoiceList.SelectedInvoice != null)
+            {
+                InvoiceDetail.Invoice = InvoiceList.SelectedInvoice;
+                DetailVisible = true;
+                DeleteInvoiceCommand.RaiseCanExecuteChanged();
+                CloseDetailCommand.RaiseCanExecuteChanged();
+            }
+        }
+
+        private void CloseDetail()
+        {
+            InvoiceDetail.Invoice = null;
+            DetailVisible = false;
+            CloseDetailCommand.RaiseCanExecuteChanged();
+            DeleteInvoiceCommand.RaiseCanExecuteChanged();
+        }
+
+        private void NewInvoice()
+        {
+            InvoiceDetail.Invoice = new Facturon.Domain.Entities.Invoice
+            {
+                Date = System.DateTime.Today,
+                Issuer = string.Empty,
+                Number = string.Empty
+            };
+            DetailVisible = true;
+            CloseDetailCommand.RaiseCanExecuteChanged();
+            DeleteInvoiceCommand.RaiseCanExecuteChanged();
+        }
+
+        private bool CanDeleteSelected() => InvoiceList.SelectedInvoice != null;
+
+        private async void DeleteSelected()
+        {
+            if (InvoiceList.SelectedInvoice != null)
+            {
+                await _invoiceService.DeleteAsync(InvoiceList.SelectedInvoice.Id);
+                InvoiceList.Invoices.Remove(InvoiceList.SelectedInvoice);
+                CloseDetail();
+            }
+        }
+    }
+}

--- a/ViewModels/RelayCommand.cs
+++ b/ViewModels/RelayCommand.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Windows.Input;
+
+namespace Facturon.App.ViewModels
+{
+    public class RelayCommand : ICommand
+    {
+        private readonly Action _execute;
+        private readonly Func<bool>? _canExecute;
+
+        public RelayCommand(Action execute, Func<bool>? canExecute = null)
+        {
+            _execute = execute;
+            _canExecute = canExecute;
+        }
+
+        public event EventHandler? CanExecuteChanged;
+
+        public bool CanExecute(object? parameter) => _canExecute == null || _canExecute();
+
+        public void Execute(object? parameter) => _execute();
+
+        public void RaiseCanExecuteChanged()
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -1,0 +1,17 @@
+<UserControl x:Class="Facturon.App.Views.InvoiceDetailView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <Grid Margin="10">
+        <StackPanel>
+            <TextBlock Text="Invoice Number:"/>
+            <TextBox Text="{Binding Invoice.Number}"/>
+            <TextBlock Text="Issuer:" Margin="0,10,0,0"/>
+            <TextBox Text="{Binding Invoice.Issuer}"/>
+            <TextBlock Text="Date:" Margin="0,10,0,0"/>
+            <TextBox Text="{Binding Invoice.Date}"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Views/InvoiceListView.xaml
+++ b/Views/InvoiceListView.xaml
@@ -1,0 +1,13 @@
+<UserControl x:Class="Facturon.App.Views.InvoiceListView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <Grid>
+        <ListBox ItemsSource="{Binding Invoices}"
+                 SelectedItem="{Binding SelectedInvoice}"
+                 DisplayMemberPath="Number"
+                 VerticalAlignment="Stretch"/>
+    </Grid>
+</UserControl>

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -1,0 +1,23 @@
+<Window x:Class="Facturon.App.Views.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Facturon.App.Views"
+        Title="Facturon" Height="450" Width="800">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+    </Window.Resources>
+    <Window.InputBindings>
+        <KeyBinding Key="Enter" Command="{Binding OpenInvoiceCommand}"/>
+        <KeyBinding Key="Escape" Command="{Binding CloseDetailCommand}"/>
+        <KeyBinding Key="Insert" Command="{Binding NewInvoiceCommand}"/>
+        <KeyBinding Key="Delete" Command="{Binding DeleteInvoiceCommand}"/>
+    </Window.InputBindings>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="3*"/>
+        </Grid.ColumnDefinitions>
+        <local:InvoiceListView DataContext="{Binding InvoiceList}"/>
+        <local:InvoiceDetailView Grid.Column="1" DataContext="{Binding InvoiceDetail}" Visibility="{Binding DetailVisible, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+    </Grid>
+</Window>


### PR DESCRIPTION
## Summary
- add BaseViewModel and RelayCommand helpers
- implement MainViewModel, InvoiceListViewModel and InvoiceDetailViewModel
- create MainWindow, InvoiceListView and InvoiceDetailView
- configure App startup to show MainWindow and load invoices
- include a light theme resource dictionary

## Testing
- `git diff --staged --stat`

------
https://chatgpt.com/codex/tasks/task_e_687ebf1a21e08322844760f4aa7f9777