### PR TITLE
Fix missing tables on first run

### DIFF
--- a/Data/DbInitializer.cs
+++ b/Data/DbInitializer.cs
@@ -18,10 +18,19 @@ namespace Facturon.Data
                 using var scope = services.CreateScope();
                 var db = scope.ServiceProvider.GetRequiredService<FacturonDbContext>();
 
-                logger.LogInformation("Running EF Core migrations...");
-                await db.Database.MigrateAsync();
+                logger.LogInformation("Checking for pending migrations...");
+                if (db.Database.GetMigrations().Any())
+                {
+                    logger.LogInformation("Running EF Core migrations...");
+                    await db.Database.MigrateAsync();
+                }
+                else
+                {
+                    logger.LogInformation("No migrations found. Ensuring database created...");
+                    await db.Database.EnsureCreatedAsync();
+                }
 
-                logger.LogInformation("Database migrated.");
+                logger.LogInformation("Database ready.");
 
                 if (!await db.Suppliers.AnyAsync())
                 {

--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -57,3 +57,5 @@ Added DbInitializer with schema checks, startup invocation, and optional seed da
 Set Unit, ProductGroup, and TaxRate navigation properties when creating Product in SeedData to satisfy C# required members.
 ## [db_agent] Implement robust DbInitializer
 Created new DbInitializer at Data/DbInitializer.cs with migration checks, schema validation, and optional seeding. Updated startup to use it.
+## [db_agent] Ensure database creation when no migrations present
+Added a check in DbInitializer to run EnsureCreated when the project has no migrations, preventing missing table errors on first run.


### PR DESCRIPTION
## Summary
- check for migrations in DbInitializer
- run `EnsureCreated` when no migrations exist
- update prompt log

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ed3785af8832296324dc69a0e127e