### PR TITLE
Fix missing LINQ using in DbInitializer

### DIFF
--- a/Data/DbInitializer.cs
+++ b/Data/DbInitializer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Facturon.Data.Initialization;
 using Microsoft.EntityFrameworkCore;

--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -59,3 +59,4 @@ Set Unit, ProductGroup, and TaxRate navigation properties when creating Product 
 Created new DbInitializer at Data/DbInitializer.cs with migration checks, schema validation, and optional seeding. Updated startup to use it.
 ## [db_agent] Ensure database creation when no migrations present
 Added a check in DbInitializer to run EnsureCreated when the project has no migrations, preventing missing table errors on first run.
+## [db_agent] Fix missing System.Linq using in DbInitializer


### PR DESCRIPTION
## Summary
- add `System.Linq` using to DbInitializer so `Any()` can be resolved
- log the change in PROMPT_LOG.md

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ed47ff7a883228c0d88617dc83933