### PR TITLE
Add comprehensive seed data with invoices

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -60,3 +60,5 @@ Created new DbInitializer at Data/DbInitializer.cs with migration checks, schema
 ## [db_agent] Ensure database creation when no migrations present
 Added a check in DbInitializer to run EnsureCreated when the project has no migrations, preventing missing table errors on first run.
 ## [db_agent] Fix missing System.Linq using in DbInitializer
+## [db_agent] Seed invoices and sample data
+Added invoice and invoice item seeding plus additional mock products, suppliers, units, groups, rates, and payment methods.


### PR DESCRIPTION
## Summary
- expand sample data to include multiple products, suppliers, and payment methods
- add seeding logic for invoices and invoice items using Bogus
- document new seeding step in `PROMPT_LOG.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ed6532cbc8322a503d97d77129667