### PR TITLE
Fix InvoiceDetailView visibility binding

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -75,3 +75,5 @@ Added visibility property with change notification for toggling the detail view.
 
 ## [ui_agent] Fix DetailVisible binding to MainViewModel
 Updated binding in MainWindow.xaml to reference DetailVisible from window context via RelativeSource.
+## [ui_agent] Fix DataContext binding for DetailVisible
+Referenced DataContext.DetailVisible when binding InvoiceDetailView visibility in MainWindow.xaml to resolve WPF error.

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -22,6 +22,6 @@
         <views:InvoiceListView DataContext="{Binding InvoiceList}" />
         <views:InvoiceDetailView Grid.Column="1"
                                 DataContext="{Binding InvoiceDetail}"
-                                Visibility="{Binding DetailVisible, Converter={StaticResource BooleanToVisibilityConverter}, RelativeSource={RelativeSource AncestorType=Window}}" />
+                                Visibility="{Binding DataContext.DetailVisible, Converter={StaticResource BooleanToVisibilityConverter}, RelativeSource={RelativeSource AncestorType=Window}}" />
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- resolve `DetailVisible` binding error by referencing `DataContext.DetailVisible`
- log the adjustment in `PROMPT_LOG`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ef01f23888322b34ed42e41423bec