### PR TITLE
Fix blank views by adding constructors

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -78,3 +78,5 @@ Updated binding in MainWindow.xaml to reference DetailVisible from window contex
 ## [ui_agent] Fix DataContext binding for DetailVisible
 Referenced DataContext.DetailVisible when binding InvoiceDetailView visibility in MainWindow.xaml to resolve WPF error.
 ## [ui_agent] Add debug logging and no-data view
+## [ui_agent] Add missing view constructors
+Added constructors in InvoiceListView and InvoiceDetailView to call InitializeComponent so their XAML content renders.

--- a/Views/InvoiceDetailView.xaml.cs
+++ b/Views/InvoiceDetailView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace Facturon.App.Views
+{
+    public partial class InvoiceDetailView : UserControl
+    {
+        public InvoiceDetailView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Views/InvoiceListView.xaml.cs
+++ b/Views/InvoiceListView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace Facturon.App.Views
+{
+    public partial class InvoiceListView : UserControl
+    {
+        public InvoiceListView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add missing code-behind classes for `InvoiceListView` and `InvoiceDetailView`
- record the change in `PROMPT_LOG.md`

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ef62d49448322bcd5f3decd0fc207