### PR TITLE
Add invoice items grid

### DIFF
--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -1,4 +1,6 @@
 using System.Windows;
+using System.Collections.Generic;
+using System.Linq;
 using Facturon.Domain.Entities;
 
 namespace Facturon.App.ViewModels
@@ -15,6 +17,7 @@ namespace Facturon.App.ViewModels
                 {
                     _invoice = value;
                     OnPropertyChanged();
+                    OnPropertyChanged(nameof(InvoiceItems));
                 }
             }
         }
@@ -32,6 +35,8 @@ namespace Facturon.App.ViewModels
                 }
             }
         }
+
+        public IEnumerable<InvoiceItem> InvoiceItems => Invoice?.Items ?? Enumerable.Empty<InvoiceItem>();
 
         // TODO: Toggle DetailVisible when invoice selection changes
     }

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -5,7 +5,11 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d">
     <Grid Margin="10">
-        <StackPanel>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0">
             <TextBlock Text="Invoice Number:"/>
             <TextBox Text="{Binding Invoice.Number}"/>
             <TextBlock Text="Issuer:" Margin="0,10,0,0"/>
@@ -13,5 +17,23 @@
             <TextBlock Text="Date:" Margin="0,10,0,0"/>
             <TextBox Text="{Binding Invoice.Date}"/>
         </StackPanel>
+        <DataGrid Grid.Row="1"
+                  ItemsSource="{Binding InvoiceItems}"
+                  AutoGenerateColumns="False"
+                  IsReadOnly="True"
+                  Margin="0,10,0,0">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Product"
+                                    Binding="{Binding Product.Name}"/>
+                <DataGridTextColumn Header="Quantity"
+                                    Binding="{Binding Quantity}"/>
+                <DataGridTextColumn Header="Unit price"
+                                    Binding="{Binding UnitPrice}"/>
+                <DataGridTextColumn Header="Net amount"
+                                    Binding="{Binding NetAmount}"/>
+                <DataGridTextColumn Header="Gross amount"
+                                    Binding="{Binding GrossAmount}"/>
+            </DataGrid.Columns>
+        </DataGrid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- expose `InvoiceItems` collection from the detail ViewModel
- show invoice items in `InvoiceDetailView` with a `DataGrid`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ef7fb4fbc8322857d003e5e6858f3