### PR TITLE
Fix invoice detail item loading

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -83,3 +83,12 @@ Created xUnit test project under `Tests` with Moq and initial tests for InvoiceS
 ## [ui_agent] Add missing view constructors
 Added constructors in InvoiceListView and InvoiceDetailView to call InitializeComponent so their XAML content renders.
 
+## [service_agent] Load invoice items in GetByIdAsync
+Enhanced InvoiceService.GetByIdAsync to eagerly load invoice items and related
+product data with Include/ThenInclude chains.
+
+## [ui_agent] Load selected invoice details
+Introduced SelectedInvoice property in MainViewModel and updated
+InvoiceDetailViewModel to subscribe to selection changes, load full invoice
+details via IInvoiceService, and expose an ObservableCollection for binding.
+

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -32,7 +32,16 @@ namespace Facturon.Services
 
         public async Task<Invoice?> GetByIdAsync(int id)
         {
-            return await _invoiceRepository.GetByIdAsync(id);
+            return await _invoiceRepository.AsQueryable()
+                .Where(i => i.Id == id)
+                .Include(i => i.Items)
+                    .ThenInclude(it => it.Product)
+                        .ThenInclude(p => p.Unit)
+                .Include(i => i.Items)
+                    .ThenInclude(it => it.Product)
+                        .ThenInclude(p => p.TaxRate)
+                .AsNoTracking()
+                .FirstOrDefaultAsync();
         }
 
         public async Task<List<Invoice>> GetAllAsync()

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -1,12 +1,27 @@
 using System.Windows;
+using System.Collections.ObjectModel;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
 using Facturon.Domain.Entities;
+using Facturon.Services;
 
 namespace Facturon.App.ViewModels
 {
     public class InvoiceDetailViewModel : BaseViewModel
     {
+        private readonly IInvoiceService _invoiceService;
+        private readonly MainViewModel _mainViewModel;
+
+        public InvoiceDetailViewModel(IInvoiceService invoiceService, MainViewModel mainViewModel)
+        {
+            _invoiceService = invoiceService;
+            _mainViewModel = mainViewModel;
+            InvoiceItems = new ObservableCollection<InvoiceItem>();
+            _mainViewModel.PropertyChanged += MainViewModel_PropertyChanged;
+        }
+
         private Invoice? _invoice;
         public Invoice? Invoice
         {
@@ -36,7 +51,39 @@ namespace Facturon.App.ViewModels
             }
         }
 
-        public IEnumerable<InvoiceItem> InvoiceItems => Invoice?.Items ?? Enumerable.Empty<InvoiceItem>();
+        private ObservableCollection<InvoiceItem> _invoiceItems;
+        public ObservableCollection<InvoiceItem> InvoiceItems
+        {
+            get => _invoiceItems;
+            private set
+            {
+                if (_invoiceItems != value)
+                {
+                    _invoiceItems = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private async void MainViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(MainViewModel.SelectedInvoice))
+                await LoadInvoiceAsync();
+        }
+
+        private async Task LoadInvoiceAsync()
+        {
+            if (_mainViewModel.SelectedInvoice == null)
+            {
+                Invoice = null;
+                InvoiceItems.Clear();
+                return;
+            }
+
+            var full = await _invoiceService.GetByIdAsync(_mainViewModel.SelectedInvoice.Id);
+            Invoice = full;
+            InvoiceItems = new ObservableCollection<InvoiceItem>(full?.Items ?? new List<InvoiceItem>());
+        }
 
         // TODO: Toggle DetailVisible when invoice selection changes
     }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using System.Diagnostics;
+using Facturon.Domain.Entities;
 using Facturon.Services;
 
 namespace Facturon.App.ViewModels
@@ -9,7 +10,20 @@ namespace Facturon.App.ViewModels
         private readonly IInvoiceService _invoiceService;
 
         public InvoiceListViewModel InvoiceList { get; }
-        public InvoiceDetailViewModel InvoiceDetail { get; } = new();
+        public InvoiceDetailViewModel InvoiceDetail { get; }
+
+        public Invoice? SelectedInvoice
+        {
+            get => InvoiceList.SelectedInvoice;
+            set
+            {
+                if (InvoiceList.SelectedInvoice != value)
+                {
+                    InvoiceList.SelectedInvoice = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         private bool _detailVisible;
         public bool DetailVisible
@@ -35,6 +49,13 @@ namespace Facturon.App.ViewModels
             Debug.WriteLine("MainViewModel created");
             _invoiceService = invoiceService;
             InvoiceList = new InvoiceListViewModel(invoiceService);
+            InvoiceList.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(InvoiceListViewModel.SelectedInvoice))
+                    OnPropertyChanged(nameof(SelectedInvoice));
+            };
+
+            InvoiceDetail = new InvoiceDetailViewModel(invoiceService, this);
 
             OpenInvoiceCommand = new RelayCommand(OpenSelected, CanOpenSelected);
             CloseDetailCommand = new RelayCommand(CloseDetail, () => DetailVisible);


### PR DESCRIPTION
## Summary
- load Invoice.Items through InvoiceService using Include/ThenInclude
- expose SelectedInvoice in MainViewModel and propagate selection
- subscribe to selection changes in InvoiceDetailViewModel and fetch items
- log agent activity in PROMPT_LOG

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ef97c3bb883228c45fee1d5822aec