### PR TITLE
Add VAT calculation for invoice lines

### DIFF
--- a/Domain/Entities/InvoiceItem.cs
+++ b/Domain/Entities/InvoiceItem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Facturon.Domain.Entities
 {
@@ -12,5 +13,18 @@ namespace Facturon.Domain.Entities
 
         public required virtual Invoice Invoice { get; set; }
         public required virtual Product Product { get; set; }
+
+        [NotMapped]
+        public decimal NetAmount => Quantity * UnitPrice;
+
+        [NotMapped]
+        public decimal GrossAmount
+        {
+            get
+            {
+                var rate = Product?.TaxRate?.Value ?? 0m;
+                return NetAmount * (1 + rate / 100m);
+            }
+        }
     }
 }

--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -92,3 +92,5 @@ Introduced SelectedInvoice property in MainViewModel and updated
 InvoiceDetailViewModel to subscribe to selection changes, load full invoice
 details via IInvoiceService, and expose an ObservableCollection for binding.
 
+## [domain_agent] Add computed NetAmount and GrossAmount to InvoiceItem
+Implemented readonly properties in InvoiceItem.cs using Product.TaxRate for VAT calculation with null safety. Added NotMapped attributes.


### PR DESCRIPTION
## Summary
- compute NetAmount and GrossAmount directly on `InvoiceItem`
- document the change in `PROMPT_LOG.md`

## Testing
- `N/A` (no tests provided and build skipped per instructions)

------
https://chatgpt.com/codex/tasks/task_e_687efc2a22a483228106b8ad718ea47b