### PR TITLE
Add fixed tax rate on invoice items

### DIFF
--- a/Data/FacturonDbContext.cs
+++ b/Data/FacturonDbContext.cs
@@ -80,6 +80,11 @@ namespace Facturon.Data
                 entity.Property(e => e.Active)
                     .HasDefaultValue(true);
 
+                entity.Property(e => e.TaxRateValue)
+                    .HasColumnType("decimal(18,2)")
+                    .HasDefaultValue(0m)
+                    .IsRequired();
+
                 entity.HasIndex(e => e.InvoiceId);
                 entity.HasIndex(e => e.ProductId);
             });

--- a/Data/Initialization/SeedData.cs
+++ b/Data/Initialization/SeedData.cs
@@ -109,7 +109,8 @@ namespace Facturon.Data.Initialization
                         Invoice = invoice,
                         Quantity = qty,
                         UnitPrice = price,
-                        Total = qty * price
+                        Total = qty * price,
+                        TaxRateValue = product.TaxRate.Value
                     };
                     invoice.Items.Add(item);
                 }

--- a/Domain/Entities/InvoiceItem.cs
+++ b/Domain/Entities/InvoiceItem.cs
@@ -11,6 +11,13 @@ namespace Facturon.Domain.Entities
         public decimal UnitPrice { get; set; }
         public decimal Total { get; set; }
 
+        /// <summary>
+        /// VAT percentage captured at the moment of invoicing.
+        /// Stored explicitly to keep historical tax values.
+        /// </summary>
+        [System.ComponentModel.DataAnnotations.Required]
+        public decimal TaxRateValue { get; set; }
+
         public required virtual Invoice Invoice { get; set; }
         public required virtual Product Product { get; set; }
 
@@ -22,8 +29,7 @@ namespace Facturon.Domain.Entities
         {
             get
             {
-                var rate = Product?.TaxRate?.Value ?? 0m;
-                return NetAmount * (1 + rate / 100m);
+                return NetAmount * (1 + TaxRateValue / 100m);
             }
         }
     }

--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -94,3 +94,18 @@ details via IInvoiceService, and expose an ObservableCollection for binding.
 
 ## [domain_agent] Add computed NetAmount and GrossAmount to InvoiceItem
 Implemented readonly properties in InvoiceItem.cs using Product.TaxRate for VAT calculation with null safety. Added NotMapped attributes.
+
+## [domain_agent] Persist tax rate value on InvoiceItem
+Added `TaxRateValue` property to InvoiceItem for storing VAT percentage and updated
+NetAmount and GrossAmount calculations to use it.
+
+## [db_agent] Configure InvoiceItem.TaxRateValue
+Mapped new field in FacturonDbContext with decimal column type and default value
+of 0.
+
+## [service_agent] Populate TaxRateValue on creation
+Invoice and InvoiceItem services now copy the product's TaxRate value when items
+are added or updated. Invoice totals calculation uses the stored value.
+
+## [test_agent] Adapt tests for fixed tax rate
+Updated InvoiceServiceTests to set TaxRateValue on invoice items for totals.

--- a/Services/InvoiceItemService.cs
+++ b/Services/InvoiceItemService.cs
@@ -53,6 +53,7 @@ namespace Facturon.Services
             if (item.UnitPrice < 0)
                 return Result.Fail("Unit price must be non-negative");
 
+            item.TaxRateValue = product.TaxRate?.Value ?? 0m;
             item.DateCreated = DateTime.UtcNow;
             item.DateUpdated = DateTime.UtcNow;
             item.Active = true;
@@ -87,6 +88,7 @@ namespace Facturon.Services
             existing.Quantity = item.Quantity;
             existing.UnitPrice = item.UnitPrice;
             existing.Total = item.Total;
+            existing.TaxRateValue = product.TaxRate?.Value ?? 0m;
             existing.DateUpdated = DateTime.UtcNow;
 
             await _invoiceRepository.UpdateAsync(invoice);

--- a/Tests/Services/InvoiceServiceTests.cs
+++ b/Tests/Services/InvoiceServiceTests.cs
@@ -88,8 +88,8 @@ namespace Facturon.Tests.Services
             {
                 Items = new List<InvoiceItem>
                 {
-                    new InvoiceItem { Quantity = 2, UnitPrice = 10, Product = product },
-                    new InvoiceItem { Quantity = 1, UnitPrice = 20, Product = product }
+                    new InvoiceItem { Quantity = 2, UnitPrice = 10, Product = product, TaxRateValue = 10 },
+                    new InvoiceItem { Quantity = 1, UnitPrice = 20, Product = product, TaxRateValue = 10 }
                 }
             };
 


### PR DESCRIPTION
## Summary
- persist `TaxRateValue` on `InvoiceItem`
- map `TaxRateValue` in `FacturonDbContext`
- copy product tax rate when creating/updating invoice items
- compute invoice totals using stored rate
- adjust seed data and tests

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687efe2257e08322b59511884f337ac0