### PR TITLE
Show rounded totals in invoice detail

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -109,3 +109,9 @@ are added or updated. Invoice totals calculation uses the stored value.
 
 ## [test_agent] Adapt tests for fixed tax rate
 Updated InvoiceServiceTests to set TaxRateValue on invoice items for totals.
+
+## [service_agent] Add GetTotalsAsync and totals rounding support
+Implemented new GetTotalsAsync method in InvoiceService and interface. InvoiceTotals now exposes NetTotal, TaxTotal and GrossTotal aliases.
+
+## [ui_agent] Display rounded invoice totals in detail view
+InvoiceDetailViewModel loads rounded totals on selection change and InvoiceDetailView shows the values under the item grid.

--- a/Services/IInvoiceService.cs
+++ b/Services/IInvoiceService.cs
@@ -12,6 +12,7 @@ namespace Facturon.Services
         Task<Result> CreateAsync(Invoice invoice);
         Task<Result> UpdateAsync(Invoice invoice);
         Task<Result> DeleteAsync(int id);
+        Task<InvoiceTotals> GetTotalsAsync(int invoiceId);
         Task<InvoiceTotals> CalculateTotalsAsync(Invoice invoice);
     }
 }

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -161,6 +161,15 @@ namespace Facturon.Services
             return Result.Ok();
         }
 
+        public async Task<InvoiceTotals> GetTotalsAsync(int invoiceId)
+        {
+            var invoice = await GetByIdAsync(invoiceId);
+            if (invoice == null)
+                return new InvoiceTotals();
+
+            return await CalculateTotalsAsync(invoice);
+        }
+
         public async Task<InvoiceTotals> CalculateTotalsAsync(Invoice invoice)
         {
             var totals = new InvoiceTotals();

--- a/Services/InvoiceTotals.cs
+++ b/Services/InvoiceTotals.cs
@@ -15,6 +15,9 @@ namespace Facturon.Services
         public decimal TotalNet { get; set; }
         public decimal TotalVat { get; set; }
         public decimal TotalGross { get; set; }
+        public decimal NetTotal => TotalNet;
+        public decimal TaxTotal => TotalVat;
+        public decimal GrossTotal => TotalGross;
         public List<TaxRateTotal> ByTaxRate { get; set; } = new();
     }
 }

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -65,6 +66,20 @@ namespace Facturon.App.ViewModels
             }
         }
 
+        private InvoiceTotals _invoiceTotals = new InvoiceTotals();
+        public InvoiceTotals InvoiceTotals
+        {
+            get => _invoiceTotals;
+            private set
+            {
+                if (_invoiceTotals != value)
+                {
+                    _invoiceTotals = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         private async void MainViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(MainViewModel.SelectedInvoice))
@@ -77,12 +92,28 @@ namespace Facturon.App.ViewModels
             {
                 Invoice = null;
                 InvoiceItems.Clear();
+                InvoiceTotals = new InvoiceTotals();
                 return;
             }
 
             var full = await _invoiceService.GetByIdAsync(_mainViewModel.SelectedInvoice.Id);
             Invoice = full;
             InvoiceItems = new ObservableCollection<InvoiceItem>(full?.Items ?? new List<InvoiceItem>());
+
+            if (full != null)
+            {
+                var totals = await _invoiceService.GetTotalsAsync(full.Id);
+                InvoiceTotals = new InvoiceTotals
+                {
+                    TotalNet = Math.Round(totals.TotalNet, 2),
+                    TotalVat = Math.Round(totals.TotalVat, 2),
+                    TotalGross = Math.Round(totals.TotalGross, 2)
+                };
+            }
+            else
+            {
+                InvoiceTotals = new InvoiceTotals();
+            }
         }
 
         // TODO: Toggle DetailVisible when invoice selection changes

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -8,6 +8,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <StackPanel Grid.Row="0">
             <TextBlock Text="Invoice Number:"/>
@@ -35,5 +36,26 @@
                                     Binding="{Binding GrossAmount}"/>
             </DataGrid.Columns>
         </DataGrid>
+
+        <StackPanel Grid.Row="2" Margin="0,10,0,0">
+            <Separator />
+            <Grid Margin="0,5,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="Net total:" />
+                <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding InvoiceTotals.NetTotal, StringFormat=F2}" HorizontalAlignment="Right" />
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="Tax:" Margin="0,5,0,0" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding InvoiceTotals.TaxTotal, StringFormat=F2}" HorizontalAlignment="Right" Margin="0,5,0,0" />
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="Total:" Margin="0,5,0,0" />
+                <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding InvoiceTotals.GrossTotal, StringFormat=F2}" HorizontalAlignment="Right" Margin="0,5,0,0" />
+            </Grid>
+        </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- add `GetTotalsAsync` to `IInvoiceService` and implement in `InvoiceService`
- expose total aliases in `InvoiceTotals`
- update `InvoiceDetailViewModel` to load rounded totals
- display totals below the items grid in `InvoiceDetailView`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f94f7e92083228b333930bd4eff8a