### PR TITLE
Add gross-based pricing toggle and exit UX

### DIFF
--- a/Data/FacturonDbContext.cs
+++ b/Data/FacturonDbContext.cs
@@ -45,6 +45,9 @@ namespace Facturon.Data
                     .OnDelete(DeleteBehavior.Restrict)
                     .IsRequired();
 
+                entity.Property(e => e.IsGrossBased)
+                    .HasDefaultValue(false);
+
                 entity.Property(e => e.DateCreated)
                     .HasDefaultValueSql("CURRENT_TIMESTAMP");
                 entity.Property(e => e.DateUpdated)

--- a/Domain/Entities/Invoice.cs
+++ b/Domain/Entities/Invoice.cs
@@ -11,6 +11,11 @@ namespace Facturon.Domain.Entities
         public int SupplierId { get; set; }
         public int PaymentMethodId { get; set; }
 
+        /// <summary>
+        /// Indicates whether invoice item prices are entered including VAT.
+        /// </summary>
+        public bool IsGrossBased { get; set; }
+
         public required virtual Supplier Supplier { get; set; }
         public required virtual PaymentMethod PaymentMethod { get; set; }
         public virtual List<InvoiceItem> Items { get; set; } = new();

--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -118,3 +118,21 @@ InvoiceDetailViewModel loads rounded totals on selection change and InvoiceDetai
 
 ## [ui_agent] Display Tax Rate in Invoice Items Grid
 Added Tax % column to InvoiceDetailView bound to InvoiceItem.TaxRateValue with right-aligned formatting.
+
+## [domain_agent] Add IsGrossBased flag to Invoice
+Added boolean property to `Invoice` entity for toggling gross based pricing.
+
+## [db_agent] Map IsGrossBased in DbContext
+Configured default value for the new flag in `FacturonDbContext`.
+
+## [ui_agent] Add price mode toggle and formatting fixes
+Inserted checkbox bound to `Invoice.IsGrossBased` and applied `StringFormat=F2` to price related columns.
+
+## [service_agent] Handle gross based price calculations
+`InvoiceItemService` now converts prices based on invoice mode when creating or updating items.
+
+## [ui_agent] Improve MainWindow interactions
+Set focus to invoice list on load and added escape exit confirmation dialog.
+
+## [test_agent] Cover gross/net price logic
+New `InvoiceItemServiceTests` verify proper price conversion for gross and net modes.

--- a/Services/InvoiceItemService.cs
+++ b/Services/InvoiceItemService.cs
@@ -60,6 +60,13 @@ namespace Facturon.Services
             item.TaxRateId = product.TaxRateId;
             item.TaxRate = rate!;
             item.TaxRateValue = rate?.Value ?? 0m;
+
+            var unit = item.UnitPrice;
+            if (invoice.IsGrossBased)
+                unit = unit / (1 + item.TaxRateValue / 100m);
+            item.UnitPrice = Math.Round(unit, 2);
+            item.Total = Math.Round(item.Quantity * item.UnitPrice, 2);
+
             item.DateCreated = DateTime.UtcNow;
             item.DateUpdated = DateTime.UtcNow;
             item.Active = true;
@@ -93,8 +100,11 @@ namespace Facturon.Services
 
             existing.ProductId = item.ProductId;
             existing.Quantity = item.Quantity;
-            existing.UnitPrice = item.UnitPrice;
-            existing.Total = item.Total;
+            var unit = item.UnitPrice;
+            if (invoice.IsGrossBased)
+                unit = unit / (1 + existing.TaxRateValue / 100m);
+            existing.UnitPrice = Math.Round(unit, 2);
+            existing.Total = Math.Round(item.Quantity * existing.UnitPrice, 2);
             existing.TaxRateId = product.TaxRateId;
             existing.TaxRate = rate!;
             existing.TaxRateValue = rate?.Value ?? 0m;

--- a/Tests/Services/InvoiceItemServiceTests.cs
+++ b/Tests/Services/InvoiceItemServiceTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Facturon.Domain.Entities;
+using Facturon.Repositories;
+using Facturon.Services;
+using Moq;
+using Xunit;
+
+namespace Facturon.Tests.Services
+{
+    public class InvoiceItemServiceTests
+    {
+        private readonly Mock<IInvoiceRepository> _invoiceRepo = new();
+        private readonly Mock<IProductRepository> _productRepo = new();
+        private readonly Mock<ITaxRateRepository> _taxRepo = new();
+
+        private InvoiceItemService CreateService() => new(_invoiceRepo.Object, _productRepo.Object, _taxRepo.Object);
+
+        [Fact]
+        public async Task CreateAsync_ConvertsGrossToNet_WhenInvoiceIsGrossBased()
+        {
+            var invoice = new Invoice { Id = 1, Active = true, IsGrossBased = true, Items = new List<InvoiceItem>() };
+            var product = new Product { Id = 2, Active = true, TaxRateId = 3 };
+            var rate = new TaxRate { Id = 3, Value = 20m };
+            var item = new InvoiceItem { InvoiceId = 1, ProductId = 2, Quantity = 1, UnitPrice = 120m };
+
+            _invoiceRepo.Setup(r => r.AsQueryable()).Returns(new List<Invoice> { invoice }.AsQueryable());
+            _productRepo.Setup(r => r.GetByIdAsync(2)).ReturnsAsync(product);
+            _taxRepo.Setup(r => r.GetByIdAsync(3)).ReturnsAsync(rate);
+            _invoiceRepo.Setup(r => r.UpdateAsync(invoice)).Returns(Task.CompletedTask);
+
+            var service = CreateService();
+            await service.CreateAsync(item);
+
+            var saved = Assert.Single(invoice.Items);
+            Assert.Equal(100m, saved.UnitPrice);
+            Assert.Equal(100m, saved.Total);
+        }
+
+        [Fact]
+        public async Task CreateAsync_KeepsNet_WhenInvoiceIsNetBased()
+        {
+            var invoice = new Invoice { Id = 1, Active = true, IsGrossBased = false, Items = new List<InvoiceItem>() };
+            var product = new Product { Id = 2, Active = true, TaxRateId = 3 };
+            var rate = new TaxRate { Id = 3, Value = 20m };
+            var item = new InvoiceItem { InvoiceId = 1, ProductId = 2, Quantity = 2, UnitPrice = 50m };
+
+            _invoiceRepo.Setup(r => r.AsQueryable()).Returns(new List<Invoice> { invoice }.AsQueryable());
+            _productRepo.Setup(r => r.GetByIdAsync(2)).ReturnsAsync(product);
+            _taxRepo.Setup(r => r.GetByIdAsync(3)).ReturnsAsync(rate);
+            _invoiceRepo.Setup(r => r.UpdateAsync(invoice)).Returns(Task.CompletedTask);
+
+            var service = CreateService();
+            await service.CreateAsync(item);
+
+            var saved = Assert.Single(invoice.Items);
+            Assert.Equal(50m, saved.UnitPrice);
+            Assert.Equal(100m, saved.Total);
+        }
+    }
+}

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -17,6 +17,9 @@
             <TextBox Text="{Binding Invoice.Issuer}"/>
             <TextBlock Text="Date:" Margin="0,10,0,0"/>
             <TextBox Text="{Binding Invoice.Date}"/>
+            <CheckBox Content="Prices include VAT"
+                      IsChecked="{Binding Invoice.IsGrossBased}"
+                      Margin="0,10,0,0"/>
         </StackPanel>
         <DataGrid Grid.Row="1"
                   ItemsSource="{Binding InvoiceItems}"
@@ -27,9 +30,9 @@
                 <DataGridTextColumn Header="Product"
                                     Binding="{Binding Product.Name}"/>
                 <DataGridTextColumn Header="Quantity"
-                                    Binding="{Binding Quantity}"/>
+                                    Binding="{Binding Quantity, StringFormat=F2}"/>
                 <DataGridTextColumn Header="Unit price"
-                                    Binding="{Binding UnitPrice}"/>
+                                    Binding="{Binding UnitPrice, StringFormat=F2}"/>
                 <DataGridTextColumn Header="Tax %"
                                     Binding="{Binding TaxRateValue, StringFormat=F0}">
                     <DataGridTextColumn.ElementStyle>
@@ -39,9 +42,9 @@
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
                 <DataGridTextColumn Header="Net amount"
-                                    Binding="{Binding NetAmount}"/>
+                                    Binding="{Binding NetAmount, StringFormat=F2}"/>
                 <DataGridTextColumn Header="Gross amount"
-                                    Binding="{Binding GrossAmount}"/>
+                                    Binding="{Binding GrossAmount, StringFormat=F2}"/>
             </DataGrid.Columns>
         </DataGrid>
 

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -5,7 +5,9 @@
         xmlns:viewModels="clr-namespace:Facturon.App.ViewModels"
         Title="Facturon"
         Height="450"
-        Width="800">
+        Width="800"
+        Loaded="Window_Loaded"
+        PreviewKeyDown="Window_PreviewKeyDown">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <DataTemplate DataType="{x:Type viewModels:InvoiceListViewModel}">
@@ -14,7 +16,6 @@
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding OpenInvoiceCommand}"/>
-        <KeyBinding Key="Escape" Command="{Binding CloseDetailCommand}"/>
         <KeyBinding Key="Insert" Command="{Binding NewInvoiceCommand}"/>
         <KeyBinding Key="Delete" Command="{Binding DeleteInvoiceCommand}"/>
     </Window.InputBindings>
@@ -23,7 +24,7 @@
             <ColumnDefinition Width="2*" />
             <ColumnDefinition Width="3*" />
         </Grid.ColumnDefinitions>
-        <views:InvoiceListView DataContext="{Binding InvoiceList}" />
+        <views:InvoiceListView x:Name="InvoiceListHost" DataContext="{Binding InvoiceList}" />
         <views:InvoiceDetailView Grid.Column="1"
                                 DataContext="{Binding InvoiceDetail}"
                                 Visibility="{Binding DataContext.DetailVisible, Converter={StaticResource BooleanToVisibilityConverter}, RelativeSource={RelativeSource AncestorType=Window}}" />

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -7,6 +7,29 @@ namespace Facturon.App.Views
         public MainWindow()
         {
             InitializeComponent();
+            Loaded += Window_Loaded;
+            PreviewKeyDown += Window_PreviewKeyDown;
+        }
+
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            InvoiceListHost.InvoiceList.Focus();
+        }
+
+        private void Window_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Escape)
+            {
+                e.Handled = true;
+                var result = MessageBox.Show(
+                    "Are you sure you want to exit?",
+                    "Confirm Exit",
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Question,
+                    MessageBoxResult.No);
+                if (result == MessageBoxResult.Yes)
+                    Close();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `IsGrossBased` flag on `Invoice`
- map new flag in `FacturonDbContext`
- update `InvoiceItemService` to convert prices depending on flag
- show price mode checkbox and format decimals to two digits
- focus invoice list on load and confirm exit on Escape
- add tests for price mode logic
- record agent activities in `PROMPT_LOG.md`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fc559c19083229f879fd64b8e3adf