### PR TITLE
Support gross/net price entry

### DIFF
--- a/Domain/Entities/InvoiceItem.cs
+++ b/Domain/Entities/InvoiceItem.cs
@@ -25,14 +25,28 @@ namespace Facturon.Domain.Entities
         public required virtual TaxRate TaxRate { get; set; }
 
         [NotMapped]
-        public decimal NetAmount => Quantity * UnitPrice;
+        public decimal NetAmount
+        {
+            get
+            {
+                if (Invoice?.IsGrossBased == true)
+                {
+                    return Quantity * UnitPrice / (1 + TaxRateValue / 100m);
+                }
+                return Quantity * UnitPrice;
+            }
+        }
 
         [NotMapped]
         public decimal GrossAmount
         {
             get
             {
-                return NetAmount * (1 + TaxRateValue / 100m);
+                if (Invoice?.IsGrossBased == true)
+                {
+                    return Quantity * UnitPrice;
+                }
+                return Quantity * UnitPrice * (1 + TaxRateValue / 100m);
             }
         }
     }

--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -136,3 +136,15 @@ Set focus to invoice list on load and added escape exit confirmation dialog.
 
 ## [test_agent] Cover gross/net price logic
 New `InvoiceItemServiceTests` verify proper price conversion for gross and net modes.
+
+## [domain_agent] Adjust invoice item amounts for gross/net mode
+`InvoiceItem.NetAmount` and `GrossAmount` now derive values based on `Invoice.IsGrossBased`.
+
+## [service_agent] Preserve entered unit price and compute totals
+`InvoiceItemService` no longer converts `UnitPrice` but sets `Total` depending on invoice mode. `InvoiceService.CalculateTotalsAsync` also respects `IsGrossBased`.
+
+## [ui_agent] Recalculate totals when price mode toggles
+Added `IsGrossBased` property in `InvoiceDetailViewModel` to trigger total recalculation and bound checkbox to it.
+
+## [test_agent] Update tests for gross/net handling
+Adjusted invoice item service tests and added gross-based totals test.

--- a/Services/InvoiceItemService.cs
+++ b/Services/InvoiceItemService.cs
@@ -62,9 +62,15 @@ namespace Facturon.Services
 
             var unit = item.UnitPrice;
             if (invoice.IsGrossBased)
-                unit = unit / (1 + item.TaxRateValue / 100m);
+            {
+                var net = unit / (1 + item.TaxRateValue / 100m);
+                item.Total = Math.Round(item.Quantity * net, 2);
+            }
+            else
+            {
+                item.Total = Math.Round(item.Quantity * unit, 2);
+            }
             item.UnitPrice = Math.Round(unit, 2);
-            item.Total = Math.Round(item.Quantity * item.UnitPrice, 2);
 
             item.DateCreated = DateTime.UtcNow;
             item.DateUpdated = DateTime.UtcNow;
@@ -101,9 +107,15 @@ namespace Facturon.Services
             existing.Quantity = item.Quantity;
             var unit = item.UnitPrice;
             if (invoice.IsGrossBased)
-                unit = unit / (1 + existing.TaxRateValue / 100m);
+            {
+                var net = unit / (1 + existing.TaxRateValue / 100m);
+                existing.Total = Math.Round(item.Quantity * net, 2);
+            }
+            else
+            {
+                existing.Total = Math.Round(item.Quantity * unit, 2);
+            }
             existing.UnitPrice = Math.Round(unit, 2);
-            existing.Total = Math.Round(item.Quantity * existing.UnitPrice, 2);
             existing.TaxRateId = product.TaxRateId;
             existing.TaxRate = rate!;
             existing.TaxRateValue = rate?.Value ?? 0m;

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -182,9 +182,22 @@ namespace Facturon.Services
             foreach (var item in invoice.Items)
             {
                 var taxRate = item.TaxRate ?? await _taxRateRepository.GetByIdAsync(item.TaxRateId);
-                var net = item.Quantity * item.UnitPrice;
-                var vat = net * item.TaxRateValue / 100m;
-                var gross = net + vat;
+                decimal net;
+                decimal vat;
+                decimal gross;
+
+                if (invoice.IsGrossBased)
+                {
+                    gross = item.Quantity * item.UnitPrice;
+                    net = gross / (1 + item.TaxRateValue / 100m);
+                    vat = gross - net;
+                }
+                else
+                {
+                    net = item.Quantity * item.UnitPrice;
+                    vat = net * item.TaxRateValue / 100m;
+                    gross = net + vat;
+                }
 
                 var codeKey = taxRate?.Code ?? string.Empty;
                 if (!groups.TryGetValue(codeKey, out var tg))

--- a/Tests/Services/InvoiceItemServiceTests.cs
+++ b/Tests/Services/InvoiceItemServiceTests.cs
@@ -18,7 +18,7 @@ namespace Facturon.Tests.Services
         private InvoiceItemService CreateService() => new(_invoiceRepo.Object, _productRepo.Object, _taxRepo.Object);
 
         [Fact]
-        public async Task CreateAsync_ConvertsGrossToNet_WhenInvoiceIsGrossBased()
+        public async Task CreateAsync_StoresGrossAndNetTotal_WhenInvoiceIsGrossBased()
         {
             var invoice = new Invoice { Id = 1, Active = true, IsGrossBased = true, Items = new List<InvoiceItem>() };
             var product = new Product { Id = 2, Active = true, TaxRateId = 3 };
@@ -34,12 +34,12 @@ namespace Facturon.Tests.Services
             await service.CreateAsync(item);
 
             var saved = Assert.Single(invoice.Items);
-            Assert.Equal(100m, saved.UnitPrice);
+            Assert.Equal(120m, saved.UnitPrice);
             Assert.Equal(100m, saved.Total);
         }
 
         [Fact]
-        public async Task CreateAsync_KeepsNet_WhenInvoiceIsNetBased()
+        public async Task CreateAsync_KeepsNetPrice_WhenInvoiceIsNetBased()
         {
             var invoice = new Invoice { Id = 1, Active = true, IsGrossBased = false, Items = new List<InvoiceItem>() };
             var product = new Product { Id = 2, Active = true, TaxRateId = 3 };

--- a/Tests/Services/InvoiceServiceTests.cs
+++ b/Tests/Services/InvoiceServiceTests.cs
@@ -113,5 +113,29 @@ namespace Facturon.Tests.Services
             Assert.Single(totals.ByTaxRate);
             Assert.Equal("A", totals.ByTaxRate[0].TaxCode);
         }
+
+        [Fact]
+        public async Task CalculateTotalsAsync_ComputesTotals_ForGrossBased()
+        {
+            var tax = new TaxRate { Id = 1, Code = "A", Value = 10 };
+            var product = new Product { Id = 1, Active = true, TaxRate = tax, TaxRateId = 1 };
+
+            var invoice = new Invoice
+            {
+                IsGrossBased = true,
+                Items = new List<InvoiceItem>
+                {
+                    new InvoiceItem { Quantity = 1, UnitPrice = 110, Product = product, TaxRateId = 1, TaxRate = tax, TaxRateValue = 10 },
+                    new InvoiceItem { Quantity = 1, UnitPrice = 220, Product = product, TaxRateId = 1, TaxRate = tax, TaxRateValue = 10 }
+                }
+            };
+
+            var service = CreateService();
+            var totals = await service.CalculateTotalsAsync(invoice);
+
+            Assert.Equal(300m, totals.TotalNet);
+            Assert.Equal(30m, totals.TotalVat);
+            Assert.Equal(330m, totals.TotalGross);
+        }
     }
 }

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -18,7 +18,7 @@
             <TextBlock Text="Date:" Margin="0,10,0,0"/>
             <TextBox Text="{Binding Invoice.Date}"/>
             <CheckBox Content="Prices include VAT"
-                      IsChecked="{Binding Invoice.IsGrossBased}"
+                      IsChecked="{Binding IsGrossBased}"
                       Margin="0,10,0,0"/>
         </StackPanel>
         <DataGrid Grid.Row="1"


### PR DESCRIPTION
## Summary
- recompute item NetAmount/GrossAmount based on invoice mode
- keep entered UnitPrice and compute totals accordingly
- update invoice totals for gross-based calculations
- recalc totals when toggling VAT mode in the UI
- adjust service and invoice totals tests
- log the change in PROMPT_LOG

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687feef3192483228c70de4f7b34aee4