### PR TITLE
Refine VAT handling and keyboard UX

### DIFF
--- a/Domain/Entities/InvoiceItem.cs
+++ b/Domain/Entities/InvoiceItem.cs
@@ -29,11 +29,17 @@ namespace Facturon.Domain.Entities
         {
             get
             {
+                decimal net;
                 if (Invoice?.IsGrossBased == true)
                 {
-                    return Quantity * UnitPrice / (1 + TaxRateValue / 100m);
+                    net = Quantity * UnitPrice / (1 + TaxRateValue / 100m);
                 }
-                return Quantity * UnitPrice;
+                else
+                {
+                    net = Quantity * UnitPrice;
+                }
+
+                return Math.Round(net, 2);
             }
         }
 
@@ -42,12 +48,21 @@ namespace Facturon.Domain.Entities
         {
             get
             {
+                decimal gross;
                 if (Invoice?.IsGrossBased == true)
                 {
-                    return Quantity * UnitPrice;
+                    gross = Quantity * UnitPrice;
                 }
-                return Quantity * UnitPrice * (1 + TaxRateValue / 100m);
+                else
+                {
+                    gross = Quantity * UnitPrice * (1 + TaxRateValue / 100m);
+                }
+
+                return Math.Round(gross, 2);
             }
         }
+
+        [NotMapped]
+        public decimal TaxAmount => Math.Round(GrossAmount - NetAmount, 2);
     }
 }

--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -148,3 +148,9 @@ Added `IsGrossBased` property in `InvoiceDetailViewModel` to trigger total recal
 
 ## [test_agent] Update tests for gross/net handling
 Adjusted invoice item service tests and added gross-based totals test.
+## [domain_agent] Round line and total amounts
+Implemented rounding for NetAmount, GrossAmount and new TaxAmount properties. Updated totals calculation and added rounding test.
+## [ui_agent] VAT breakdown view
+Added tax amount column and totals per VAT rate in invoice detail.
+## [ui_agent] Navigation tweaks
+Default focus on invoice list, arrow navigation for items, and new Esc exit dialog.

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -199,6 +199,10 @@ namespace Facturon.Services
                     gross = net + vat;
                 }
 
+                net = Math.Round(net, 2);
+                vat = Math.Round(vat, 2);
+                gross = Math.Round(gross, 2);
+
                 var codeKey = taxRate?.Code ?? string.Empty;
                 if (!groups.TryGetValue(codeKey, out var tg))
                 {

--- a/Tests/Services/InvoiceServiceTests.cs
+++ b/Tests/Services/InvoiceServiceTests.cs
@@ -137,5 +137,27 @@ namespace Facturon.Tests.Services
             Assert.Equal(30m, totals.TotalVat);
             Assert.Equal(330m, totals.TotalGross);
         }
+
+        [Fact]
+        public async Task CalculateTotalsAsync_RoundsToTwoDecimals()
+        {
+            var tax = new TaxRate { Id = 1, Code = "A", Value = 17.5m };
+            var product = new Product { Id = 1, Active = true, TaxRate = tax, TaxRateId = 1 };
+
+            var invoice = new Invoice
+            {
+                Items = new List<InvoiceItem>
+                {
+                    new InvoiceItem { Quantity = 1, UnitPrice = 9.994m, Product = product, TaxRateId = 1, TaxRate = tax, TaxRateValue = 17.5m }
+                }
+            };
+
+            var service = CreateService();
+            var totals = await service.CalculateTotalsAsync(invoice);
+
+            Assert.Equal(9.99m, totals.TotalNet);
+            Assert.Equal(1.75m, totals.TotalVat);
+            Assert.Equal(11.74m, totals.TotalGross);
+        }
     }
 }

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -123,7 +123,16 @@ namespace Facturon.App.ViewModels
                 {
                     TotalNet = Math.Round(totals.TotalNet, 2),
                     TotalVat = Math.Round(totals.TotalVat, 2),
-                    TotalGross = Math.Round(totals.TotalGross, 2)
+                    TotalGross = Math.Round(totals.TotalGross, 2),
+                    ByTaxRate = totals.ByTaxRate
+                        .Select(tg => new TaxRateTotal
+                        {
+                            TaxCode = tg.TaxCode,
+                            Net = Math.Round(tg.Net, 2),
+                            Vat = Math.Round(tg.Vat, 2),
+                            Gross = Math.Round(tg.Gross, 2)
+                        })
+                        .ToList()
                 };
             }
             else
@@ -142,7 +151,16 @@ namespace Facturon.App.ViewModels
             {
                 TotalNet = Math.Round(totals.TotalNet, 2),
                 TotalVat = Math.Round(totals.TotalVat, 2),
-                TotalGross = Math.Round(totals.TotalGross, 2)
+                TotalGross = Math.Round(totals.TotalGross, 2),
+                ByTaxRate = totals.ByTaxRate
+                    .Select(tg => new TaxRateTotal
+                    {
+                        TaxCode = tg.TaxCode,
+                        Net = Math.Round(tg.Net, 2),
+                        Vat = Math.Round(tg.Vat, 2),
+                        Gross = Math.Round(tg.Gross, 2)
+                    })
+                    .ToList()
             };
             OnPropertyChanged(nameof(InvoiceItems));
         }

--- a/Views/ConfirmExitWindow.xaml
+++ b/Views/ConfirmExitWindow.xaml
@@ -1,0 +1,17 @@
+<Window x:Class="Facturon.App.Views.ConfirmExitWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Confirm Exit"
+        WindowStartupLocation="CenterOwner"
+        SizeToContent="WidthAndHeight"
+        ResizeMode="NoResize"
+        WindowStyle="ToolWindow"
+        KeyDown="Window_KeyDown">
+    <StackPanel Margin="10">
+        <TextBlock Text="Do you really want to exit?" Margin="0,0,0,10"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="YesButton" Content="Yes" Margin="0,0,5,0" Width="75" Click="YesButton_Click"/>
+            <Button x:Name="NoButton" Content="No" IsDefault="True" IsCancel="True" Width="75" Click="NoButton_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Views/ConfirmExitWindow.xaml.cs
+++ b/Views/ConfirmExitWindow.xaml.cs
@@ -1,0 +1,31 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Facturon.App.Views
+{
+    public partial class ConfirmExitWindow : Window
+    {
+        public ConfirmExitWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void YesButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+
+        private void NoButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                DialogResult = true;
+            }
+        }
+    }
+}

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -25,6 +25,7 @@
                   ItemsSource="{Binding InvoiceItems}"
                   AutoGenerateColumns="False"
                   IsReadOnly="True"
+                  SelectionUnit="FullRow"
                   Margin="0,10,0,0">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Product"
@@ -41,6 +42,8 @@
                         </Style>
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
+                <DataGridTextColumn Header="Tax amount"
+                                    Binding="{Binding TaxAmount, StringFormat=F2}"/>
                 <DataGridTextColumn Header="Net amount"
                                     Binding="{Binding NetAmount, StringFormat=F2}"/>
                 <DataGridTextColumn Header="Gross amount"
@@ -67,6 +70,18 @@
                 <TextBlock Grid.Row="2" Grid.Column="0" Text="Total:" Margin="0,5,0,0" />
                 <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding InvoiceTotals.GrossTotal, StringFormat=F2}" HorizontalAlignment="Right" Margin="0,5,0,0" />
             </Grid>
+            <DataGrid ItemsSource="{Binding InvoiceTotals.ByTaxRate}"
+                      AutoGenerateColumns="False"
+                      HeadersVisibility="Column"
+                      IsReadOnly="True"
+                      Margin="0,10,0,0">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Tax %" Binding="{Binding TaxCode}" />
+                    <DataGridTextColumn Header="Net" Binding="{Binding Net, StringFormat=F2}" />
+                    <DataGridTextColumn Header="VAT" Binding="{Binding Vat, StringFormat=F2}" />
+                    <DataGridTextColumn Header="Gross" Binding="{Binding Gross, StringFormat=F2}" />
+                </DataGrid.Columns>
+            </DataGrid>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Views/InvoiceListView.xaml
+++ b/Views/InvoiceListView.xaml
@@ -3,7 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d">
+             mc:Ignorable="d"
+             FocusManager.FocusedElement="{Binding ElementName=InvoiceList}"
+             Loaded="UserControl_Loaded">
     <Grid>
         <ListBox x:Name="InvoiceList"
                  ItemsSource="{Binding Invoices}"

--- a/Views/InvoiceListView.xaml.cs
+++ b/Views/InvoiceListView.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows.Controls;
+using System.Windows;
 
 namespace Facturon.App.Views
 {
@@ -7,6 +8,13 @@ namespace Facturon.App.Views
         public InvoiceListView()
         {
             InitializeComponent();
+        }
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (InvoiceList.Items.Count > 0 && InvoiceList.SelectedIndex == -1)
+                InvoiceList.SelectedIndex = 0;
+            InvoiceList.Focus();
         }
     }
 }

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -21,13 +21,9 @@ namespace Facturon.App.Views
             if (e.Key == System.Windows.Input.Key.Escape)
             {
                 e.Handled = true;
-                var result = MessageBox.Show(
-                    "Are you sure you want to exit?",
-                    "Confirm Exit",
-                    MessageBoxButton.YesNo,
-                    MessageBoxImage.Question,
-                    MessageBoxResult.No);
-                if (result == MessageBoxResult.Yes)
+                var dlg = new ConfirmExitWindow { Owner = this };
+                var result = dlg.ShowDialog();
+                if (result == true)
                     Close();
             }
         }


### PR DESCRIPTION
## Summary
- round invoice item amounts to 2 decimals and expose TaxAmount
- show VAT breakdown per rate in invoice detail view
- improve keyboard-first navigation and custom exit confirmation dialog
- document these changes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff11a99d48322bdc9bb7300673b73