### PR TITLE
Fix item VAT recalculation when switching modes

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -154,3 +154,6 @@ Implemented rounding for NetAmount, GrossAmount and new TaxAmount properties. Up
 Added tax amount column and totals per VAT rate in invoice detail.
 ## [ui_agent] Navigation tweaks
 Default focus on invoice list, arrow navigation for items, and new Esc exit dialog.
+
+## [ui_agent] Dynamic item VAT recalculation
+Implemented InvoiceItemViewModel with recomputation logic. InvoiceDetailViewModel now updates item amounts when pricing mode toggles. Added unit tests for RecalculateAmounts.

--- a/Tests/Facturon.Tests.csproj
+++ b/Tests/Facturon.Tests.csproj
@@ -14,5 +14,6 @@
     <ProjectReference Include="..\Domain\Facturon.Domain.csproj" />
     <ProjectReference Include="..\Repositories\Facturon.Repositories.csproj" />
     <ProjectReference Include="..\Services\Facturon.Services.csproj" />
+    <ProjectReference Include="..\Startup\Facturon.App.csproj" />
   </ItemGroup>
 </Project>

--- a/Tests/ViewModels/InvoiceItemViewModelTests.cs
+++ b/Tests/ViewModels/InvoiceItemViewModelTests.cs
@@ -1,0 +1,53 @@
+using Facturon.App.ViewModels;
+using Facturon.Domain.Entities;
+using Xunit;
+
+namespace Facturon.Tests.ViewModels
+{
+    public class InvoiceItemViewModelTests
+    {
+        [Fact]
+        public void RecalculateAmounts_ToGrossBased_ComputesValues()
+        {
+            var invoice = new Invoice { IsGrossBased = false };
+            var item = new InvoiceItem
+            {
+                Quantity = 2,
+                UnitPrice = 10m,
+                TaxRateValue = 20m,
+                Product = new Product(),
+                TaxRate = new TaxRate(),
+                Invoice = invoice
+            };
+
+            var vm = new InvoiceItemViewModel(item);
+            vm.RecalculateAmounts(true);
+
+            Assert.Equal(20m, vm.GrossAmount);
+            Assert.Equal(16.67m, vm.NetAmount);
+            Assert.Equal(3.33m, vm.TaxAmount);
+        }
+
+        [Fact]
+        public void RecalculateAmounts_ToNetBased_ComputesValues()
+        {
+            var invoice = new Invoice { IsGrossBased = true };
+            var item = new InvoiceItem
+            {
+                Quantity = 1,
+                UnitPrice = 110m,
+                TaxRateValue = 10m,
+                Product = new Product(),
+                TaxRate = new TaxRate(),
+                Invoice = invoice
+            };
+
+            var vm = new InvoiceItemViewModel(item);
+            vm.RecalculateAmounts(false);
+
+            Assert.Equal(110m, vm.GrossAmount);
+            Assert.Equal(100m, vm.NetAmount);
+            Assert.Equal(10m, vm.TaxAmount);
+        }
+    }
+}

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -19,7 +19,7 @@ namespace Facturon.App.ViewModels
         {
             _invoiceService = invoiceService;
             _mainViewModel = mainViewModel;
-            InvoiceItems = new ObservableCollection<InvoiceItem>();
+            InvoiceItems = new ObservableCollection<InvoiceItemViewModel>();
             _mainViewModel.PropertyChanged += MainViewModel_PropertyChanged;
         }
 
@@ -48,6 +48,8 @@ namespace Facturon.App.ViewModels
                 {
                     Invoice.IsGrossBased = value;
                     OnPropertyChanged();
+                    foreach (var item in InvoiceItems)
+                        item.RecalculateAmounts(value);
                     _ = RecalculateTotalsAsync();
                 }
             }
@@ -67,8 +69,8 @@ namespace Facturon.App.ViewModels
             }
         }
 
-        private ObservableCollection<InvoiceItem> _invoiceItems;
-        public ObservableCollection<InvoiceItem> InvoiceItems
+        private ObservableCollection<InvoiceItemViewModel> _invoiceItems;
+        public ObservableCollection<InvoiceItemViewModel> InvoiceItems
         {
             get => _invoiceItems;
             private set
@@ -113,7 +115,10 @@ namespace Facturon.App.ViewModels
 
             var full = await _invoiceService.GetByIdAsync(_mainViewModel.SelectedInvoice.Id);
             Invoice = full;
-            InvoiceItems = new ObservableCollection<InvoiceItem>(full?.Items ?? new List<InvoiceItem>());
+            InvoiceItems = new ObservableCollection<InvoiceItemViewModel>(
+                full?.Items.Select(i => new InvoiceItemViewModel(i)) ?? new List<InvoiceItemViewModel>());
+            foreach (var item in InvoiceItems)
+                item.RecalculateAmounts(IsGrossBased);
             OnPropertyChanged(nameof(IsGrossBased));
 
             if (full != null)

--- a/ViewModels/InvoiceItemViewModel.cs
+++ b/ViewModels/InvoiceItemViewModel.cs
@@ -1,0 +1,84 @@
+using System;
+using Facturon.Domain.Entities;
+
+namespace Facturon.App.ViewModels
+{
+    public class InvoiceItemViewModel : BaseViewModel
+    {
+        public InvoiceItemViewModel(InvoiceItem item)
+        {
+            Item = item;
+            NetAmount = item.NetAmount;
+            GrossAmount = item.GrossAmount;
+            TaxAmount = item.TaxAmount;
+        }
+
+        public InvoiceItem Item { get; }
+
+        public Product Product => Item.Product;
+        public decimal Quantity => Item.Quantity;
+        public decimal UnitPrice => Item.UnitPrice;
+        public decimal TaxRateValue => Item.TaxRateValue;
+
+        private decimal _netAmount;
+        public decimal NetAmount
+        {
+            get => _netAmount;
+            private set
+            {
+                if (_netAmount != value)
+                {
+                    _netAmount = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private decimal _grossAmount;
+        public decimal GrossAmount
+        {
+            get => _grossAmount;
+            private set
+            {
+                if (_grossAmount != value)
+                {
+                    _grossAmount = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private decimal _taxAmount;
+        public decimal TaxAmount
+        {
+            get => _taxAmount;
+            private set
+            {
+                if (_taxAmount != value)
+                {
+                    _taxAmount = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public void RecalculateAmounts(bool isGrossBased)
+        {
+            if (TaxRateValue == 0)
+                return;
+
+            if (isGrossBased)
+            {
+                GrossAmount = Math.Round(Quantity * UnitPrice, 2);
+                NetAmount = Math.Round(GrossAmount / (1 + TaxRateValue / 100m), 2);
+                TaxAmount = Math.Round(GrossAmount - NetAmount, 2);
+            }
+            else
+            {
+                NetAmount = Math.Round(Quantity * UnitPrice, 2);
+                TaxAmount = Math.Round(NetAmount * (TaxRateValue / 100m), 2);
+                GrossAmount = Math.Round(NetAmount + TaxAmount, 2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `InvoiceItemViewModel` to recalc Net/Gross/Tax amounts
- refresh item view models in `InvoiceDetailViewModel` when `IsGrossBased` changes
- expose recalc logic in new tests
- log prompt entry

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff3d5e96c83229bc986472395cc4d