### PR TITLE
Add inline combo creation control

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -163,3 +163,5 @@ Added x:Name and AutomationProperties.Name on key controls for Appium tests.
 
 ## [test_agent] Add WinAppDriver UI test
 Created InvoiceUITests using MSTest and Appium WebDriver.
+## [orchestrator_agent] Editable combo with inline creation
+Implemented generic `EditableComboWithAdd` control and view model. Added `IEntityService<T>` and explicit implementations in services with DI wiring. InvoiceDetailView now hosts supplier/product/unit/tax rate/product group pickers using the new control.

--- a/Services/IEntityService.cs
+++ b/Services/IEntityService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Facturon.Services
+{
+    public interface IEntityService<T>
+    {
+        Task<IEnumerable<T>> GetAllAsync();
+        Task<T> CreateAsync(T entity);
+    }
+}

--- a/Services/ProductGroupService.cs
+++ b/Services/ProductGroupService.cs
@@ -6,7 +6,7 @@ using Facturon.Repositories;
 
 namespace Facturon.Services
 {
-    public class ProductGroupService : IProductGroupService
+    public class ProductGroupService : IProductGroupService, IEntityService<ProductGroup>
     {
         private readonly IProductGroupRepository _groupRepository;
         private readonly IProductRepository _productRepository;
@@ -63,6 +63,17 @@ namespace Facturon.Services
 
             await _groupRepository.DeleteAsync(id);
             return Result.Ok();
+        }
+
+        async Task<IEnumerable<ProductGroup>> IEntityService<ProductGroup>.GetAllAsync()
+        {
+            return await GetAllAsync();
+        }
+
+        async Task<ProductGroup> IEntityService<ProductGroup>.CreateAsync(ProductGroup entity)
+        {
+            await _groupRepository.AddAsync(entity);
+            return entity;
         }
     }
 }

--- a/Services/ProductService.cs
+++ b/Services/ProductService.cs
@@ -7,7 +7,7 @@ using Facturon.Repositories;
 
 namespace Facturon.Services
 {
-    public class ProductService : IProductService
+    public class ProductService : IProductService, IEntityService<Product>
     {
         private readonly IProductRepository _productRepository;
         private readonly IUnitRepository _unitRepository;
@@ -95,6 +95,17 @@ namespace Facturon.Services
             if (taxRate == null || !taxRate.Active) return false;
 
             return true;
+        }
+
+        async Task<IEnumerable<Product>> IEntityService<Product>.GetAllAsync()
+        {
+            return await GetAllAsync();
+        }
+
+        async Task<Product> IEntityService<Product>.CreateAsync(Product entity)
+        {
+            await _productRepository.AddAsync(entity);
+            return entity;
         }
     }
 }

--- a/Services/SupplierService.cs
+++ b/Services/SupplierService.cs
@@ -6,7 +6,7 @@ using Facturon.Repositories;
 
 namespace Facturon.Services
 {
-    public class SupplierService : ISupplierService
+    public class SupplierService : ISupplierService, IEntityService<Supplier>
     {
         private readonly ISupplierRepository _supplierRepository;
         private readonly IInvoiceRepository _invoiceRepository;
@@ -63,6 +63,17 @@ namespace Facturon.Services
 
             await _supplierRepository.DeleteAsync(id);
             return Result.Ok();
+        }
+
+        async Task<IEnumerable<Supplier>> IEntityService<Supplier>.GetAllAsync()
+        {
+            return await GetAllAsync();
+        }
+
+        async Task<Supplier> IEntityService<Supplier>.CreateAsync(Supplier entity)
+        {
+            await _supplierRepository.AddAsync(entity);
+            return entity;
         }
     }
 }

--- a/Services/TaxRateService.cs
+++ b/Services/TaxRateService.cs
@@ -6,7 +6,7 @@ using Facturon.Repositories;
 
 namespace Facturon.Services
 {
-    public class TaxRateService : ITaxRateService
+    public class TaxRateService : ITaxRateService, IEntityService<TaxRate>
     {
         private readonly ITaxRateRepository _taxRateRepository;
         private readonly IProductRepository _productRepository;
@@ -63,6 +63,17 @@ namespace Facturon.Services
 
             await _taxRateRepository.DeleteAsync(id);
             return Result.Ok();
+        }
+
+        async Task<IEnumerable<TaxRate>> IEntityService<TaxRate>.GetAllAsync()
+        {
+            return await GetAllAsync();
+        }
+
+        async Task<TaxRate> IEntityService<TaxRate>.CreateAsync(TaxRate entity)
+        {
+            await _taxRateRepository.AddAsync(entity);
+            return entity;
         }
     }
 }

--- a/Services/UnitService.cs
+++ b/Services/UnitService.cs
@@ -6,7 +6,7 @@ using Facturon.Repositories;
 
 namespace Facturon.Services
 {
-    public class UnitService : IUnitService
+    public class UnitService : IUnitService, IEntityService<Unit>
     {
         private readonly IUnitRepository _unitRepository;
         private readonly IProductRepository _productRepository;
@@ -63,6 +63,17 @@ namespace Facturon.Services
 
             await _unitRepository.DeleteAsync(id);
             return Result.Ok();
+        }
+
+        async Task<IEnumerable<Unit>> IEntityService<Unit>.GetAllAsync()
+        {
+            return await GetAllAsync();
+        }
+
+        async Task<Unit> IEntityService<Unit>.CreateAsync(Unit entity)
+        {
+            await _unitRepository.AddAsync(entity);
+            return entity;
         }
     }
 }

--- a/Startup/StartupOrchestrator.cs
+++ b/Startup/StartupOrchestrator.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Facturon.Data;
 using Facturon.Repositories;
 using Facturon.Services;
+using Facturon.Domain.Entities;
 using Facturon.App.ViewModels;
 using Facturon.App.Views;
 using Microsoft.EntityFrameworkCore;
@@ -49,6 +50,12 @@ namespace Facturon.App
                     services.AddScoped<ISupplierService, SupplierService>();
                     services.AddScoped<ITaxRateService, TaxRateService>();
                     services.AddScoped<IUnitService, UnitService>();
+
+                    services.AddScoped<IEntityService<Supplier>, SupplierService>();
+                    services.AddScoped<IEntityService<Product>, ProductService>();
+                    services.AddScoped<IEntityService<Unit>, UnitService>();
+                    services.AddScoped<IEntityService<TaxRate>, TaxRateService>();
+                    services.AddScoped<IEntityService<ProductGroup>, ProductGroupService>();
 
                     services.AddSingleton<MainWindow>();
                     services.AddTransient<InvoiceListViewModel>();

--- a/ViewModels/EditableComboWithAddViewModel.cs
+++ b/ViewModels/EditableComboWithAddViewModel.cs
@@ -1,0 +1,127 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Input;
+using Facturon.Services;
+using Facturon.App.Views;
+
+namespace Facturon.App.ViewModels
+{
+    public class EditableComboWithAddViewModel<T> : BaseViewModel, ICommandSource
+        where T : class, new()
+    {
+        private readonly IEntityService<T> _service;
+
+        public ObservableCollection<T> AllItems { get; }
+
+        private T? _selectedItem;
+        public T? SelectedItem
+        {
+            get => _selectedItem;
+            set
+            {
+                if (!Equals(_selectedItem, value))
+                {
+                    _selectedItem = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private string _typedText = string.Empty;
+        public string TypedText
+        {
+            get => _typedText;
+            set
+            {
+                if (_typedText != value)
+                {
+                    _typedText = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private bool _isCreatingNew;
+        public bool IsCreatingNew
+        {
+            get => _isCreatingNew;
+            set
+            {
+                if (_isCreatingNew != value)
+                {
+                    _isCreatingNew = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private T? _newItem;
+        public T? NewItem
+        {
+            get => _newItem;
+            set
+            {
+                if (!Equals(_newItem, value))
+                {
+                    _newItem = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public ICommand CheckIfNewItemCommand { get; }
+        public ICommand CreateNewItemCommand { get; }
+        public ICommand SaveNewItemCommand { get; }
+        public ICommand CancelNewItemCommand { get; }
+
+        public EditableComboWithAddViewModel(IEntityService<T> service)
+        {
+            _service = service;
+            AllItems = new ObservableCollection<T>(service.GetAllAsync().Result);
+
+            CheckIfNewItemCommand = new RelayCommand(CheckIfNewItem);
+            CreateNewItemCommand = new RelayCommand(StartCreate);
+            SaveNewItemCommand = new RelayCommand(SaveNew);
+            CancelNewItemCommand = new RelayCommand(CancelCreate);
+        }
+
+        private void CheckIfNewItem()
+        {
+            if (string.IsNullOrWhiteSpace(TypedText))
+                return;
+
+            if (AllItems.Contains(SelectedItem))
+                return;
+
+            var result = MessageBox.Show($"\"{TypedText}\" nem létezik. Új elem?",
+                "Új", MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No);
+            if (result == MessageBoxResult.Yes)
+                StartCreate();
+        }
+
+        private void StartCreate()
+        {
+            NewItem = new T();
+            IsCreatingNew = true;
+        }
+
+        private async void SaveNew()
+        {
+            if (NewItem == null)
+                return;
+
+            var created = await _service.CreateAsync(NewItem);
+            AllItems.Add(created);
+            SelectedItem = created;
+            IsCreatingNew = false;
+            TypedText = string.Empty;
+        }
+
+        private void CancelCreate()
+        {
+            IsCreatingNew = false;
+            NewItem = null;
+            TypedText = string.Empty;
+        }
+    }
+}

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -14,11 +14,28 @@ namespace Facturon.App.ViewModels
     {
         private readonly IInvoiceService _invoiceService;
         private readonly MainViewModel _mainViewModel;
+        public EditableComboWithAddViewModel<Supplier> SupplierPickerVM { get; }
+        public EditableComboWithAddViewModel<Product> ProductPickerVM { get; }
+        public EditableComboWithAddViewModel<Unit> UnitPickerVM { get; }
+        public EditableComboWithAddViewModel<TaxRate> TaxRatePickerVM { get; }
+        public EditableComboWithAddViewModel<ProductGroup> ProductGroupPickerVM { get; }
 
-        public InvoiceDetailViewModel(IInvoiceService invoiceService, MainViewModel mainViewModel)
+        public InvoiceDetailViewModel(
+            IInvoiceService invoiceService,
+            MainViewModel mainViewModel,
+            IEntityService<Supplier> supplierService,
+            IEntityService<Product> productService,
+            IEntityService<Unit> unitService,
+            IEntityService<TaxRate> taxRateService,
+            IEntityService<ProductGroup> productGroupService)
         {
             _invoiceService = invoiceService;
             _mainViewModel = mainViewModel;
+            SupplierPickerVM = new EditableComboWithAddViewModel<Supplier>(supplierService);
+            ProductPickerVM = new EditableComboWithAddViewModel<Product>(productService);
+            UnitPickerVM = new EditableComboWithAddViewModel<Unit>(unitService);
+            TaxRatePickerVM = new EditableComboWithAddViewModel<TaxRate>(taxRateService);
+            ProductGroupPickerVM = new EditableComboWithAddViewModel<ProductGroup>(productGroupService);
             InvoiceItems = new ObservableCollection<InvoiceItemViewModel>();
             _mainViewModel.PropertyChanged += MainViewModel_PropertyChanged;
         }

--- a/Views/Controls/EditableComboWithAdd.xaml
+++ b/Views/Controls/EditableComboWithAdd.xaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="Facturon.App.Views.EditableComboWithAdd"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+    </UserControl.Resources>
+    <StackPanel>
+        <ComboBox IsEditable="True"
+                  ItemsSource="{Binding AllItems}"
+                  SelectedItem="{Binding SelectedItem}"
+                  Text="{Binding TypedText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                  LostFocus="ComboBox_LostFocus"
+                  KeyDown="ComboBox_KeyDown" />
+        <ContentControl Content="{Binding NewItem}"
+                        ContentTemplate="{Binding InlineCreateTemplate, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                        Visibility="{Binding IsCreatingNew, Converter={StaticResource BoolToVis}}" />
+    </StackPanel>
+</UserControl>

--- a/Views/Controls/EditableComboWithAdd.xaml.cs
+++ b/Views/Controls/EditableComboWithAdd.xaml.cs
@@ -1,0 +1,48 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Facturon.App.Views
+{
+    public partial class EditableComboWithAdd : UserControl
+    {
+        public EditableComboWithAdd()
+        {
+            InitializeComponent();
+        }
+
+        public static readonly DependencyProperty InlineCreateTemplateProperty = DependencyProperty.Register(
+            nameof(InlineCreateTemplate), typeof(DataTemplate), typeof(EditableComboWithAdd), new PropertyMetadata(null));
+
+        public DataTemplate? InlineCreateTemplate
+        {
+            get => (DataTemplate?)GetValue(InlineCreateTemplateProperty);
+            set => SetValue(InlineCreateTemplateProperty, value);
+        }
+
+        private void ComboBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                if (DataContext is ICommandSource cmdSrc && cmdSrc.CheckIfNewItemCommand?.CanExecute(null) == true)
+                {
+                    cmdSrc.CheckIfNewItemCommand.Execute(null);
+                    e.Handled = true;
+                }
+            }
+        }
+
+        private void ComboBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ICommandSource cmdSrc && cmdSrc.CheckIfNewItemCommand?.CanExecute(null) == true)
+            {
+                cmdSrc.CheckIfNewItemCommand.Execute(null);
+            }
+        }
+    }
+
+    public interface ICommandSource
+    {
+        ICommand CheckIfNewItemCommand { get; }
+    }
+}

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -3,7 +3,39 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:Facturon.App.Views"
              mc:Ignorable="d">
+    <UserControl.Resources>
+        <DataTemplate x:Key="SupplierInlineCreate">
+            <StackPanel>
+                <TextBox Text="{Binding Name}" PlaceholderText="Name" />
+                <TextBox Text="{Binding Address}" PlaceholderText="Address" />
+                <TextBox Text="{Binding TaxNumber}" PlaceholderText="Tax number" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate x:Key="ProductInlineCreate">
+            <StackPanel>
+                <TextBox Text="{Binding Name}" PlaceholderText="Name" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate x:Key="UnitInlineCreate">
+            <StackPanel>
+                <TextBox Text="{Binding Name}" PlaceholderText="Name" />
+                <TextBox Text="{Binding ShortName}" PlaceholderText="Short" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate x:Key="TaxRateInlineCreate">
+            <StackPanel>
+                <TextBox Text="{Binding Code}" PlaceholderText="Code" />
+                <TextBox Text="{Binding Value}" PlaceholderText="Value" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate x:Key="ProductGroupInlineCreate">
+            <StackPanel>
+                <TextBox Text="{Binding Name}" PlaceholderText="Name" />
+            </StackPanel>
+        </DataTemplate>
+    </UserControl.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -28,6 +60,26 @@
                       Content="Prices include VAT"
                       IsChecked="{Binding IsGrossBased}"
                       Margin="0,10,0,0"/>
+            <TextBlock Text="Supplier:" Margin="0,10,0,0" />
+            <controls:EditableComboWithAdd x:Name="SupplierCombo"
+                                           DataContext="{Binding SupplierPickerVM}"
+                                           InlineCreateTemplate="{StaticResource SupplierInlineCreate}" />
+            <TextBlock Text="Product:" Margin="0,10,0,0" />
+            <controls:EditableComboWithAdd x:Name="ProductCombo"
+                                           DataContext="{Binding ProductPickerVM}"
+                                           InlineCreateTemplate="{StaticResource ProductInlineCreate}" />
+            <TextBlock Text="Unit:" Margin="0,10,0,0" />
+            <controls:EditableComboWithAdd x:Name="UnitCombo"
+                                           DataContext="{Binding UnitPickerVM}"
+                                           InlineCreateTemplate="{StaticResource UnitInlineCreate}" />
+            <TextBlock Text="Tax Rate:" Margin="0,10,0,0" />
+            <controls:EditableComboWithAdd x:Name="TaxRateCombo"
+                                           DataContext="{Binding TaxRatePickerVM}"
+                                           InlineCreateTemplate="{StaticResource TaxRateInlineCreate}" />
+            <TextBlock Text="Product Group:" Margin="0,10,0,0" />
+            <controls:EditableComboWithAdd x:Name="ProductGroupCombo"
+                                           DataContext="{Binding ProductGroupPickerVM}"
+                                           InlineCreateTemplate="{StaticResource ProductGroupInlineCreate}" />
         </StackPanel>
         <DataGrid x:Name="ItemsGrid"
                   AutomationProperties.Name="InvoiceItems"


### PR DESCRIPTION
## Summary
- introduce `IEntityService<T>` with DI setup
- implement `EditableComboWithAddViewModel` and new `EditableComboWithAdd` user control
- wire services to the new interface
- extend `InvoiceDetailViewModel` with picker view models
- add editable combo controls to `InvoiceDetailView`
- log update in `PROMPT_LOG.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68800ee2d4308322a4e49fc5790b7fd3