### PR TITLE
Fix build error from PlaceholderText property

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -165,3 +165,6 @@ Added x:Name and AutomationProperties.Name on key controls for Appium tests.
 Created InvoiceUITests using MSTest and Appium WebDriver.
 ## [orchestrator_agent] Editable combo with inline creation
 Implemented generic `EditableComboWithAdd` control and view model. Added `IEntityService<T>` and explicit implementations in services with DI wiring. InvoiceDetailView now hosts supplier/product/unit/tax rate/product group pickers using the new control.
+
+## [ui_agent] Remove unsupported PlaceholderText properties
+Removed PlaceholderText attributes from InvoiceDetailView templates to fix build errors.

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -8,31 +8,31 @@
     <UserControl.Resources>
         <DataTemplate x:Key="SupplierInlineCreate">
             <StackPanel>
-                <TextBox Text="{Binding Name}" PlaceholderText="Name" />
-                <TextBox Text="{Binding Address}" PlaceholderText="Address" />
-                <TextBox Text="{Binding TaxNumber}" PlaceholderText="Tax number" />
+                <TextBox Text="{Binding Name}" />
+                <TextBox Text="{Binding Address}" />
+                <TextBox Text="{Binding TaxNumber}" />
             </StackPanel>
         </DataTemplate>
         <DataTemplate x:Key="ProductInlineCreate">
             <StackPanel>
-                <TextBox Text="{Binding Name}" PlaceholderText="Name" />
+                <TextBox Text="{Binding Name}" />
             </StackPanel>
         </DataTemplate>
         <DataTemplate x:Key="UnitInlineCreate">
             <StackPanel>
-                <TextBox Text="{Binding Name}" PlaceholderText="Name" />
-                <TextBox Text="{Binding ShortName}" PlaceholderText="Short" />
+                <TextBox Text="{Binding Name}" />
+                <TextBox Text="{Binding ShortName}" />
             </StackPanel>
         </DataTemplate>
         <DataTemplate x:Key="TaxRateInlineCreate">
             <StackPanel>
-                <TextBox Text="{Binding Code}" PlaceholderText="Code" />
-                <TextBox Text="{Binding Value}" PlaceholderText="Value" />
+                <TextBox Text="{Binding Code}" />
+                <TextBox Text="{Binding Value}" />
             </StackPanel>
         </DataTemplate>
         <DataTemplate x:Key="ProductGroupInlineCreate">
             <StackPanel>
-                <TextBox Text="{Binding Name}" PlaceholderText="Name" />
+                <TextBox Text="{Binding Name}" />
             </StackPanel>
         </DataTemplate>
     </UserControl.Resources>


### PR DESCRIPTION
## Summary
- remove unsupported `PlaceholderText` attributes from inline creation templates in `InvoiceDetailView`
- log this fix in `PROMPT_LOG`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688011dfa5dc832293e56dbbb598686d