### PR TITLE
Fix EditableComboWithAdd build errors

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -168,3 +168,6 @@ Implemented generic `EditableComboWithAdd` control and view model. Added `IEntit
 
 ## [ui_agent] Remove unsupported PlaceholderText properties
 Removed PlaceholderText attributes from InvoiceDetailView templates to fix build errors.
+
+## [ui_agent] Fix EditableComboWithAdd compile issues
+Renamed local ICommandSource interface to avoid clash with WPF and removed `new()` generic constraint by using Activator.CreateInstance.

--- a/ViewModels/EditableComboWithAddViewModel.cs
+++ b/ViewModels/EditableComboWithAddViewModel.cs
@@ -3,11 +3,12 @@ using System.Windows;
 using System.Windows.Input;
 using Facturon.Services;
 using Facturon.App.Views;
+using System;
 
 namespace Facturon.App.ViewModels
 {
-    public class EditableComboWithAddViewModel<T> : BaseViewModel, ICommandSource
-        where T : class, new()
+    public class EditableComboWithAddViewModel<T> : BaseViewModel, INewItemCommandSource
+        where T : class
     {
         private readonly IEntityService<T> _service;
 
@@ -101,7 +102,7 @@ namespace Facturon.App.ViewModels
 
         private void StartCreate()
         {
-            NewItem = new T();
+            NewItem = Activator.CreateInstance<T>();
             IsCreatingNew = true;
         }
 

--- a/Views/Controls/EditableComboWithAdd.xaml.cs
+++ b/Views/Controls/EditableComboWithAdd.xaml.cs
@@ -24,7 +24,7 @@ namespace Facturon.App.Views
         {
             if (e.Key == Key.Enter)
             {
-                if (DataContext is ICommandSource cmdSrc && cmdSrc.CheckIfNewItemCommand?.CanExecute(null) == true)
+                if (DataContext is INewItemCommandSource cmdSrc && cmdSrc.CheckIfNewItemCommand?.CanExecute(null) == true)
                 {
                     cmdSrc.CheckIfNewItemCommand.Execute(null);
                     e.Handled = true;
@@ -34,14 +34,14 @@ namespace Facturon.App.Views
 
         private void ComboBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            if (DataContext is ICommandSource cmdSrc && cmdSrc.CheckIfNewItemCommand?.CanExecute(null) == true)
+            if (DataContext is INewItemCommandSource cmdSrc && cmdSrc.CheckIfNewItemCommand?.CanExecute(null) == true)
             {
                 cmdSrc.CheckIfNewItemCommand.Execute(null);
             }
         }
     }
 
-    public interface ICommandSource
+    public interface INewItemCommandSource
     {
         ICommand CheckIfNewItemCommand { get; }
     }


### PR DESCRIPTION
## Summary
- rename `ICommandSource` to `INewItemCommandSource` in EditableComboWithAdd control
- relax `EditableComboWithAddViewModel` generic constraint and use `Activator.CreateInstance`
- log UI agent change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880166b30108322a9c678ac0a7f826b