### PR TITLE
Fix EditableComboWithAdd namespace

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -171,3 +171,6 @@ Removed PlaceholderText attributes from InvoiceDetailView templates to fix build
 
 ## [ui_agent] Fix EditableComboWithAdd compile issues
 Renamed local ICommandSource interface to avoid clash with WPF and removed `new()` generic constraint by using Activator.CreateInstance.
+
+## [ui_agent] Namespace cleanup for EditableComboWithAdd
+Moved the control and interface into a Controls namespace and updated InvoiceDetailView and ViewModel references.

--- a/ViewModels/EditableComboWithAddViewModel.cs
+++ b/ViewModels/EditableComboWithAddViewModel.cs
@@ -2,7 +2,7 @@ using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Input;
 using Facturon.Services;
-using Facturon.App.Views;
+using Facturon.App.Views.Controls;
 using System;
 
 namespace Facturon.App.ViewModels

--- a/Views/Controls/EditableComboWithAdd.xaml
+++ b/Views/Controls/EditableComboWithAdd.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Facturon.App.Views.EditableComboWithAdd"
+<UserControl x:Class="Facturon.App.Views.Controls.EditableComboWithAdd"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <UserControl.Resources>

--- a/Views/Controls/EditableComboWithAdd.xaml.cs
+++ b/Views/Controls/EditableComboWithAdd.xaml.cs
@@ -2,7 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 
-namespace Facturon.App.Views
+namespace Facturon.App.Views.Controls
 {
     public partial class EditableComboWithAdd : UserControl
     {

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:controls="clr-namespace:Facturon.App.Views"
+             xmlns:controls="clr-namespace:Facturon.App.Views.Controls"
              mc:Ignorable="d">
     <UserControl.Resources>
         <DataTemplate x:Key="SupplierInlineCreate">


### PR DESCRIPTION
## Summary
- move `EditableComboWithAdd` into a `Controls` namespace
- update `InvoiceDetailView` and view model to reference the new namespace
- document namespace cleanup in `PROMPT_LOG`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688018a76fd4832291bbc6d7690afb85