### PR TITLE
Fix build errors in InvoiceDetail

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -174,3 +174,6 @@ Renamed local ICommandSource interface to avoid clash with WPF and removed `new(
 
 ## [ui_agent] Namespace cleanup for EditableComboWithAdd
 Moved the control and interface into a Controls namespace and updated InvoiceDetailView and ViewModel references.
+
+## [ui_agent] Fix build-time errors
+Resolved missing service parameters and updated control namespace.

--- a/ViewModels/EditableComboWithAddViewModel.cs
+++ b/ViewModels/EditableComboWithAddViewModel.cs
@@ -91,7 +91,7 @@ namespace Facturon.App.ViewModels
             if (string.IsNullOrWhiteSpace(TypedText))
                 return;
 
-            if (AllItems.Contains(SelectedItem))
+            if (SelectedItem != null && AllItems.Contains(SelectedItem))
                 return;
 
             var result = MessageBox.Show($"\"{TypedText}\" nem létezik. Új elem?",

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -86,7 +86,7 @@ namespace Facturon.App.ViewModels
             }
         }
 
-        private ObservableCollection<InvoiceItemViewModel> _invoiceItems;
+        private ObservableCollection<InvoiceItemViewModel> _invoiceItems = new ObservableCollection<InvoiceItemViewModel>();
         public ObservableCollection<InvoiceItemViewModel> InvoiceItems
         {
             get => _invoiceItems;

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -44,7 +44,13 @@ namespace Facturon.App.ViewModels
         public RelayCommand NewInvoiceCommand { get; }
         public RelayCommand DeleteInvoiceCommand { get; }
 
-        public MainViewModel(IInvoiceService invoiceService)
+        public MainViewModel(
+            IInvoiceService invoiceService,
+            IEntityService<Supplier> supplierService,
+            IEntityService<Product> productService,
+            IEntityService<Unit> unitService,
+            IEntityService<TaxRate> taxRateService,
+            IEntityService<ProductGroup> productGroupService)
         {
             Debug.WriteLine("MainViewModel created");
             _invoiceService = invoiceService;
@@ -55,7 +61,14 @@ namespace Facturon.App.ViewModels
                     OnPropertyChanged(nameof(SelectedInvoice));
             };
 
-            InvoiceDetail = new InvoiceDetailViewModel(invoiceService, this);
+            InvoiceDetail = new InvoiceDetailViewModel(
+                invoiceService,
+                this,
+                supplierService,
+                productService,
+                unitService,
+                taxRateService,
+                productGroupService);
 
             OpenInvoiceCommand = new RelayCommand(OpenSelected, CanOpenSelected);
             CloseDetailCommand = new RelayCommand(CloseDetail, () => DetailVisible);

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:controls="clr-namespace:Facturon.App.Views.Controls"
+             xmlns:controls="clr-namespace:Facturon.App.Views.Controls;assembly=Facturon.App"
              mc:Ignorable="d">
     <UserControl.Resources>
         <DataTemplate x:Key="SupplierInlineCreate">


### PR DESCRIPTION
## Summary
- adjust `MainViewModel` to pass entity services to `InvoiceDetailViewModel`
- initialize `_invoiceItems` field
- guard null `SelectedItem` check
- specify `Facturon.App` assembly for custom controls
- log build-error fix in `PROMPT_LOG.md`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68801b042c1c832288cd49d2b9d104ed