### PR TITLE
Fix EditableComboWithAdd namespace

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -177,3 +177,6 @@ Moved the control and interface into a Controls namespace and updated InvoiceDet
 
 ## [ui_agent] Fix build-time errors
 Resolved missing service parameters and updated control namespace.
+
+## [ui_agent] Fix EditableComboWithAdd namespace
+Removed assembly qualifier from InvoiceDetailView control namespace to resolve designer errors.

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:controls="clr-namespace:Facturon.App.Views.Controls;assembly=Facturon.App"
+            xmlns:controls="clr-namespace:Facturon.App.Views.Controls"
              mc:Ignorable="d">
     <UserControl.Resources>
         <DataTemplate x:Key="SupplierInlineCreate">


### PR DESCRIPTION
## Summary
- fix `InvoiceDetailView` so the control namespace doesn't specify assembly
- document change in `PROMPT_LOG.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68801cac8840832292e5f01c91f70565