### PR TITLE
Fix build error with custom navigation enum

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -169,3 +169,6 @@ Created InvoiceUITests using MSTest and Appium WebDriver.
 - Created basic EntityCreateDialog and related view model for inline creation.
 - Added interfaces for confirmation and navigation services.
 
+
+## [service_agent] Replace WPF FocusNavigationDirection
+Added local FocusNavigationDirection enum to Services and updated INavigationService to avoid WPF dependency.

--- a/Services/FocusNavigationDirection.cs
+++ b/Services/FocusNavigationDirection.cs
@@ -1,0 +1,14 @@
+namespace Facturon.Services
+{
+    public enum FocusNavigationDirection
+    {
+        Next,
+        Previous,
+        First,
+        Last,
+        Left,
+        Right,
+        Up,
+        Down
+    }
+}

--- a/Services/INavigationService.cs
+++ b/Services/INavigationService.cs
@@ -1,5 +1,3 @@
-using System.Windows.Input;
-
 namespace Facturon.Services
 {
     public interface INavigationService


### PR DESCRIPTION
## Summary
- remove dependency on `System.Windows.Input` from `INavigationService`
- introduce a local `FocusNavigationDirection` enum
- log this change in `PROMPT_LOG.md`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880260661b883229427e237316de382