### PR TITLE
Add inline tax rate creation dialog

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -191,3 +191,8 @@ Added local FocusNavigationDirection enum to Services and updated INavigationSer
 ## [orchestrator_agent] Wire up inline unit creation
 - Modified NewProductDialogViewModel to use EditableComboWithAddViewModel for units.
 - New units are saved through dialog service and selected automatically.
+## [ui_agent] Implement tax rate creation dialog
+- Added NewTaxRateDialog view and view model with validation and keyboard support.
+- Created NewTaxRateDialogService and registered it in Startup.
+- Updated NewProductDialog to use EditableComboWithAdd for tax rates.
+- Extended NewProductDialogService and ViewModel to use the new dialog.

--- a/Startup/NewProductDialogService.cs
+++ b/Startup/NewProductDialogService.cs
@@ -13,6 +13,7 @@ namespace Facturon.App
         private readonly IProductService _productService;
         private readonly IConfirmationDialogService _confirmationService;
         private readonly INewEntityDialogService<Unit> _unitDialogService;
+        private readonly INewEntityDialogService<TaxRate> _taxRateDialogService;
 
         public NewProductDialogService(
             IUnitService unitService,
@@ -20,7 +21,8 @@ namespace Facturon.App
             IProductGroupService productGroupService,
             IProductService productService,
             IConfirmationDialogService confirmationService,
-            INewEntityDialogService<Unit> unitDialogService)
+            INewEntityDialogService<Unit> unitDialogService,
+            INewEntityDialogService<TaxRate> taxRateDialogService)
         {
             _unitService = unitService;
             _taxRateService = taxRateService;
@@ -28,6 +30,7 @@ namespace Facturon.App
             _productService = productService;
             _confirmationService = confirmationService;
             _unitDialogService = unitDialogService;
+            _taxRateDialogService = taxRateDialogService;
         }
 
         public Product? ShowDialog()
@@ -39,7 +42,8 @@ namespace Facturon.App
                 _productGroupService,
                 _productService,
                 _confirmationService,
-                _unitDialogService);
+                _unitDialogService,
+                _taxRateDialogService);
             vm.Initialize();
             dialog.DataContext = vm;
             vm.CloseRequested += p => dialog.DialogResult = p != null;

--- a/Startup/NewTaxRateDialogService.cs
+++ b/Startup/NewTaxRateDialogService.cs
@@ -1,0 +1,20 @@
+using Facturon.Domain.Entities;
+using Facturon.Services;
+using Facturon.App.ViewModels.Dialogs;
+using Facturon.App.Views.Dialogs;
+
+namespace Facturon.App
+{
+    public class NewTaxRateDialogService : INewEntityDialogService<TaxRate>
+    {
+        public TaxRate? ShowDialog()
+        {
+            var dialog = new NewTaxRateDialog();
+            var vm = new NewTaxRateDialogViewModel();
+            dialog.DataContext = vm;
+            vm.CloseRequested += r => dialog.DialogResult = r != null;
+            var result = dialog.ShowDialog();
+            return result == true ? vm.Rate : null;
+        }
+    }
+}

--- a/Startup/StartupOrchestrator.cs
+++ b/Startup/StartupOrchestrator.cs
@@ -55,6 +55,7 @@ namespace Facturon.App
                     services.AddSingleton<INewEntityDialogService<Supplier>, NewSupplierDialogService>();
                     services.AddSingleton<INewEntityDialogService<Product>, NewProductDialogService>();
                     services.AddSingleton<INewEntityDialogService<Unit>, NewUnitDialogService>();
+                    services.AddSingleton<INewEntityDialogService<TaxRate>, NewTaxRateDialogService>();
 
                     services.AddSingleton<MainWindow>();
                     services.AddTransient<InvoiceListViewModel>();

--- a/ViewModels/Dialogs/NewTaxRateDialogViewModel.cs
+++ b/ViewModels/Dialogs/NewTaxRateDialogViewModel.cs
@@ -1,0 +1,91 @@
+using System;
+using System.ComponentModel;
+using Facturon.Domain.Entities;
+
+namespace Facturon.App.ViewModels.Dialogs
+{
+    public class NewTaxRateDialogViewModel : BaseViewModel, IDataErrorInfo
+    {
+        public TaxRate Rate { get; } = new()
+        {
+            Code = string.Empty,
+            Value = 0m,
+            ValidFrom = DateTime.Today,
+            ValidTo = DateTime.Today
+        };
+
+        private DateTime? _validTo;
+        public DateTime? ValidTo
+        {
+            get => _validTo;
+            set
+            {
+                if (_validTo != value)
+                {
+                    _validTo = value;
+                    OnPropertyChanged();
+                    SaveCommand.RaiseCanExecuteChanged();
+                }
+            }
+        }
+
+        private bool _isActive = true;
+        public bool IsActive
+        {
+            get => _isActive;
+            set
+            {
+                if (_isActive != value)
+                {
+                    _isActive = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public RelayCommand SaveCommand { get; }
+        public RelayCommand CancelCommand { get; }
+
+        public event Action<TaxRate?>? CloseRequested;
+
+        public NewTaxRateDialogViewModel()
+        {
+            SaveCommand = new RelayCommand(Save, CanSave);
+            CancelCommand = new RelayCommand(() => CloseRequested?.Invoke(null));
+        }
+
+        private bool CanSave()
+        {
+            return string.IsNullOrWhiteSpace(Rate.Code) == false
+                   && Rate.Value >= 0 && Rate.Value <= 100
+                   && (ValidTo == null || Rate.ValidFrom <= ValidTo);
+        }
+
+        private void Save()
+        {
+            Rate.ValidTo = ValidTo ?? DateTime.MaxValue;
+            Rate.Active = IsActive;
+            CloseRequested?.Invoke(Rate);
+        }
+
+        public string Error => string.Empty;
+
+        public string this[string columnName]
+        {
+            get
+            {
+                return columnName switch
+                {
+                    nameof(Rate.Code) => string.IsNullOrWhiteSpace(Rate.Code)
+                        ? "Required" : string.Empty,
+                    nameof(Rate.Value) => Rate.Value < 0 || Rate.Value > 100
+                        ? "0-100" : string.Empty,
+                    nameof(Rate.ValidFrom) or nameof(ValidTo) =>
+                        ValidTo != null && ValidTo < Rate.ValidFrom
+                            ? "Invalid range" : string.Empty,
+                    _ => string.Empty
+                };
+            }
+        }
+    }
+}

--- a/Views/Dialogs/NewTaxRateDialog.xaml
+++ b/Views/Dialogs/NewTaxRateDialog.xaml
@@ -1,0 +1,42 @@
+<Window x:Class="Facturon.App.Views.Dialogs.NewTaxRateDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="New Tax Rate"
+        WindowStartupLocation="CenterOwner"
+        SizeToContent="WidthAndHeight"
+        WindowStyle="ToolWindow"
+        FocusManager.FocusedElement="{Binding ElementName=CancelButton}">
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="200" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Code:" Grid.Row="0" Grid.Column="0" Margin="0,0,5,0" />
+        <TextBox x:Name="CodeBox" Grid.Row="0" Grid.Column="1" Text="{Binding Rate.Code, UpdateSourceTrigger=PropertyChanged}" />
+
+        <TextBlock Text="Value (%):" Grid.Row="1" Grid.Column="0" Margin="0,5,5,0" />
+        <TextBox Grid.Row="1" Grid.Column="1" Margin="0,5,0,0" Text="{Binding Rate.Value, UpdateSourceTrigger=PropertyChanged}" />
+
+        <TextBlock Text="Valid From:" Grid.Row="2" Grid.Column="0" Margin="0,5,5,0" />
+        <DatePicker Grid.Row="2" Grid.Column="1" Margin="0,5,0,0" SelectedDate="{Binding Rate.ValidFrom}" />
+
+        <TextBlock Text="Valid To:" Grid.Row="3" Grid.Column="0" Margin="0,5,5,0" />
+        <DatePicker Grid.Row="3" Grid.Column="1" Margin="0,5,0,0" SelectedDate="{Binding ValidTo}" />
+
+        <CheckBox Content="Active" Grid.Row="4" Grid.Column="1" Margin="0,5,0,0" IsChecked="{Binding IsActive}" />
+
+        <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Right">
+            <Button x:Name="OkButton" Content="OK" Width="75" Margin="0,0,5,0" IsDefault="True" Command="{Binding SaveCommand}" />
+            <Button x:Name="CancelButton" Content="Cancel" Width="75" IsCancel="True" Command="{Binding CancelCommand}" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Views/Dialogs/NewTaxRateDialog.xaml.cs
+++ b/Views/Dialogs/NewTaxRateDialog.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Facturon.App.Views.Dialogs
+{
+    public partial class NewTaxRateDialog : Window
+    {
+        public NewTaxRateDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Views/NewProductDialog.xaml
+++ b/Views/NewProductDialog.xaml
@@ -14,10 +14,8 @@
         <views:EditableComboWithAdd Width="200"
                                     DataContext="{Binding UnitSelector}" />
         <TextBlock Text="Tax Rate:" Margin="0,5,0,0"/>
-        <ComboBox Width="200"
-                  ItemsSource="{Binding TaxRates}"
-                  DisplayMemberPath="Code"
-                  SelectedItem="{Binding SelectedTaxRate}" />
+        <views:EditableComboWithAdd Width="200"
+                                    DataContext="{Binding TaxRateSelector}" />
         <TextBlock Text="Product Group:" Margin="0,5,0,0"/>
         <ComboBox Width="200"
                   ItemsSource="{Binding ProductGroups}"


### PR DESCRIPTION
## Summary
- add NewTaxRateDialog view and ViewModel for creating tax rates
- implement NewTaxRateDialogService and register in DI
- switch product dialog to EditableComboWithAdd for tax rates
- extend NewProductDialogService and ViewModel
- document the change in PROMPT_LOG

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68803aacb75483229519184ab2da95d3