### PR TITLE
Add inline ProductGroup creation dialog

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -196,3 +196,8 @@ Added local FocusNavigationDirection enum to Services and updated INavigationSer
 - Created NewTaxRateDialogService and registered it in Startup.
 - Updated NewProductDialog to use EditableComboWithAdd for tax rates.
 - Extended NewProductDialogService and ViewModel to use the new dialog.
+## [ui_agent] Implement product group creation dialog
+- Added NewProductGroupDialog view and view model for inline creation.
+- Created ProductGroupSelectorViewModel and dialog service.
+- Updated NewProductDialog to use editable combo with inline group creation.
+- Registered NewProductGroupDialogService in Startup.

--- a/Startup/NewProductDialogService.cs
+++ b/Startup/NewProductDialogService.cs
@@ -14,6 +14,7 @@ namespace Facturon.App
         private readonly IConfirmationDialogService _confirmationService;
         private readonly INewEntityDialogService<Unit> _unitDialogService;
         private readonly INewEntityDialogService<TaxRate> _taxRateDialogService;
+        private readonly INewEntityDialogService<ProductGroup> _productGroupDialogService;
 
         public NewProductDialogService(
             IUnitService unitService,
@@ -22,7 +23,8 @@ namespace Facturon.App
             IProductService productService,
             IConfirmationDialogService confirmationService,
             INewEntityDialogService<Unit> unitDialogService,
-            INewEntityDialogService<TaxRate> taxRateDialogService)
+            INewEntityDialogService<TaxRate> taxRateDialogService,
+            INewEntityDialogService<ProductGroup> productGroupDialogService)
         {
             _unitService = unitService;
             _taxRateService = taxRateService;
@@ -31,6 +33,7 @@ namespace Facturon.App
             _confirmationService = confirmationService;
             _unitDialogService = unitDialogService;
             _taxRateDialogService = taxRateDialogService;
+            _productGroupDialogService = productGroupDialogService;
         }
 
         public Product? ShowDialog()
@@ -43,7 +46,8 @@ namespace Facturon.App
                 _productService,
                 _confirmationService,
                 _unitDialogService,
-                _taxRateDialogService);
+                _taxRateDialogService,
+                _productGroupDialogService);
             vm.Initialize();
             dialog.DataContext = vm;
             vm.CloseRequested += p => dialog.DialogResult = p != null;

--- a/Startup/NewProductGroupDialogService.cs
+++ b/Startup/NewProductGroupDialogService.cs
@@ -1,0 +1,20 @@
+using Facturon.Domain.Entities;
+using Facturon.Services;
+using Facturon.App.ViewModels.Dialogs;
+using Facturon.App.Views.Dialogs;
+
+namespace Facturon.App
+{
+    public class NewProductGroupDialogService : INewEntityDialogService<ProductGroup>
+    {
+        public ProductGroup? ShowDialog()
+        {
+            var dialog = new NewProductGroupDialog();
+            var vm = new NewProductGroupDialogViewModel();
+            dialog.DataContext = vm;
+            vm.CloseRequested += g => dialog.DialogResult = g != null;
+            var result = dialog.ShowDialog();
+            return result == true ? vm.Group : null;
+        }
+    }
+}

--- a/Startup/StartupOrchestrator.cs
+++ b/Startup/StartupOrchestrator.cs
@@ -56,6 +56,7 @@ namespace Facturon.App
                     services.AddSingleton<INewEntityDialogService<Product>, NewProductDialogService>();
                     services.AddSingleton<INewEntityDialogService<Unit>, NewUnitDialogService>();
                     services.AddSingleton<INewEntityDialogService<TaxRate>, NewTaxRateDialogService>();
+                    services.AddSingleton<INewEntityDialogService<ProductGroup>, NewProductGroupDialogService>();
 
                     services.AddSingleton<MainWindow>();
                     services.AddTransient<InvoiceListViewModel>();

--- a/ViewModels/Dialogs/NewProductGroupDialogViewModel.cs
+++ b/ViewModels/Dialogs/NewProductGroupDialogViewModel.cs
@@ -1,0 +1,48 @@
+using System;
+using Facturon.Domain.Entities;
+
+namespace Facturon.App.ViewModels.Dialogs
+{
+    public class NewProductGroupDialogViewModel : BaseViewModel
+    {
+        public ProductGroup Group { get; } = new ProductGroup
+        {
+            Name = string.Empty
+        };
+
+        private string? _description;
+        public string? Description
+        {
+            get => _description;
+            set
+            {
+                if (_description != value)
+                {
+                    _description = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public RelayCommand SaveCommand { get; }
+        public RelayCommand CancelCommand { get; }
+
+        public event Action<ProductGroup?>? CloseRequested;
+
+        public NewProductGroupDialogViewModel()
+        {
+            SaveCommand = new RelayCommand(Save, CanSave);
+            CancelCommand = new RelayCommand(() => CloseRequested?.Invoke(null));
+        }
+
+        private bool CanSave()
+        {
+            return !string.IsNullOrWhiteSpace(Group.Name);
+        }
+
+        private void Save()
+        {
+            CloseRequested?.Invoke(Group);
+        }
+    }
+}

--- a/ViewModels/ProductGroupSelectorViewModel.cs
+++ b/ViewModels/ProductGroupSelectorViewModel.cs
@@ -1,0 +1,16 @@
+using Facturon.Domain.Entities;
+using Facturon.Services;
+
+namespace Facturon.App.ViewModels
+{
+    public class ProductGroupSelectorViewModel : EditableComboWithAddViewModel<ProductGroup>
+    {
+        public ProductGroupSelectorViewModel(
+            IProductGroupService service,
+            IConfirmationDialogService confirmationService,
+            INewEntityDialogService<ProductGroup> dialogService)
+            : base(service, confirmationService, dialogService)
+        {
+        }
+    }
+}

--- a/Views/Dialogs/NewProductGroupDialog.xaml
+++ b/Views/Dialogs/NewProductGroupDialog.xaml
@@ -1,0 +1,33 @@
+<Window x:Class="Facturon.App.Views.Dialogs.NewProductGroupDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="New Product Group"
+        WindowStartupLocation="CenterOwner"
+        SizeToContent="WidthAndHeight"
+        WindowStyle="ToolWindow"
+        FocusManager.FocusedElement="{Binding ElementName=NameBox}">
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="200" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Name:" Grid.Row="0" Grid.Column="0" Margin="0,0,5,0" />
+        <TextBox x:Name="NameBox" Grid.Row="0" Grid.Column="1"
+                 Text="{Binding Group.Name, UpdateSourceTrigger=PropertyChanged}" />
+
+        <TextBlock Text="Description:" Grid.Row="1" Grid.Column="0" Margin="0,5,5,0" />
+        <TextBox Grid.Row="1" Grid.Column="1" Margin="0,5,0,0"
+                 Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}" />
+
+        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Right">
+            <Button Content="OK" Width="75" Margin="0,0,5,0" IsDefault="True" Command="{Binding SaveCommand}" />
+            <Button Content="Cancel" Width="75" IsCancel="True" Command="{Binding CancelCommand}" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Views/Dialogs/NewProductGroupDialog.xaml.cs
+++ b/Views/Dialogs/NewProductGroupDialog.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Facturon.App.Views.Dialogs
+{
+    public partial class NewProductGroupDialog : Window
+    {
+        public NewProductGroupDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Views/NewProductDialog.xaml
+++ b/Views/NewProductDialog.xaml
@@ -17,10 +17,8 @@
         <views:EditableComboWithAdd Width="200"
                                     DataContext="{Binding TaxRateSelector}" />
         <TextBlock Text="Product Group:" Margin="0,5,0,0"/>
-        <ComboBox Width="200"
-                  ItemsSource="{Binding ProductGroups}"
-                  DisplayMemberPath="Name"
-                  SelectedItem="{Binding SelectedProductGroup}" />
+        <views:EditableComboWithAdd Width="200"
+                                    DataContext="{Binding ProductGroupSelector}" />
         <TextBlock Text="Net Unit Price:" Margin="0,5,0,0"/>
         <TextBox Width="200" Text="{Binding NetUnitPrice, UpdateSourceTrigger=PropertyChanged}" />
         <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Right">


### PR DESCRIPTION
## Summary
- implement `NewProductGroupDialog` with keyboard-friendly layout
- add `NewProductGroupDialogViewModel` and selector view model
- enable inline ProductGroup creation in `NewProductDialog`
- add `NewProductGroupDialogService` and register in startup
- update prompt log

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688099b75c4c8322bed82153412f335c