### PR TITLE
Filter tax rate selection by validity

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -201,3 +201,7 @@ Added local FocusNavigationDirection enum to Services and updated INavigationSer
 - Created ProductGroupSelectorViewModel and dialog service.
 - Updated NewProductDialog to use editable combo with inline group creation.
 - Registered NewProductGroupDialogService in Startup.
+## [service_agent] Filter tax rates by date
+- Added GetActiveForDateAsync to ITaxRateService and implemented in TaxRateService.
+- Created TaxRateSelectorViewModel to load rates valid on a given date.
+- Updated NewProductDialogViewModel to initialize tax rate selector with today's date.

--- a/Services/ITaxRateService.cs
+++ b/Services/ITaxRateService.cs
@@ -7,6 +7,7 @@ namespace Facturon.Services
     public interface ITaxRateService : IEntityService<TaxRate>
     {
         Task<TaxRate?> GetByIdAsync(int id);
+        Task<List<TaxRate>> GetActiveForDateAsync(DateTime date);
         Task<Result> UpdateAsync(TaxRate rate);
         Task<Result> DeleteAsync(int id);
     }

--- a/Services/TaxRateService.cs
+++ b/Services/TaxRateService.cs
@@ -27,6 +27,13 @@ namespace Facturon.Services
             return await _taxRateRepository.GetAllAsync();
         }
 
+        public async Task<List<TaxRate>> GetActiveForDateAsync(DateTime date)
+        {
+            return await _taxRateRepository.GetByConditionAsync(r =>
+                r.Active && r.ValidFrom <= date &&
+                (r.ValidTo >= date));
+        }
+
         public async Task<Result> CreateAsync(TaxRate rate)
         {
             rate.DateCreated = DateTime.UtcNow;

--- a/ViewModels/NewProductDialogViewModel.cs
+++ b/ViewModels/NewProductDialogViewModel.cs
@@ -18,7 +18,7 @@ namespace Facturon.App.ViewModels
         private readonly INewEntityDialogService<ProductGroup> _productGroupDialogService;
 
         public EditableComboWithAddViewModel<Unit> UnitSelector { get; }
-        public EditableComboWithAddViewModel<TaxRate> TaxRateSelector { get; }
+        public TaxRateSelectorViewModel TaxRateSelector { get; }
         public ProductGroupSelectorViewModel ProductGroupSelector { get; }
 
         public Product Product { get; } = new Product
@@ -73,7 +73,7 @@ namespace Facturon.App.ViewModels
 
             UnitSelector = new EditableComboWithAddViewModel<Unit>(_unitService, _confirmationService, _unitDialogService);
             UnitSelector.PropertyChanged += UnitSelectorOnPropertyChanged;
-            TaxRateSelector = new EditableComboWithAddViewModel<TaxRate>(_taxRateService, _confirmationService, _taxRateDialogService);
+            TaxRateSelector = new TaxRateSelectorViewModel(_taxRateService, _confirmationService, _taxRateDialogService);
             TaxRateSelector.PropertyChanged += TaxRateSelectorOnPropertyChanged;
             ProductGroupSelector = new ProductGroupSelectorViewModel(_productGroupService, _confirmationService, _productGroupDialogService);
             ProductGroupSelector.PropertyChanged += ProductGroupSelectorOnPropertyChanged;
@@ -117,7 +117,7 @@ namespace Facturon.App.ViewModels
         public void Initialize()
         {
             UnitSelector.InitializeAsync().GetAwaiter().GetResult();
-            TaxRateSelector.InitializeAsync().GetAwaiter().GetResult();
+            TaxRateSelector.InitializeAsync(DateTime.Today).GetAwaiter().GetResult();
             ProductGroupSelector.InitializeAsync().GetAwaiter().GetResult();
         }
 

--- a/ViewModels/TaxRateSelectorViewModel.cs
+++ b/ViewModels/TaxRateSelectorViewModel.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using Facturon.Domain.Entities;
+using Facturon.Services;
+
+namespace Facturon.App.ViewModels
+{
+    public class TaxRateSelectorViewModel : EditableComboWithAddViewModel<TaxRate>
+    {
+        private readonly ITaxRateService _taxRateService;
+
+        public TaxRateSelectorViewModel(
+            ITaxRateService service,
+            IConfirmationDialogService confirmationService,
+            INewEntityDialogService<TaxRate> dialogService)
+            : base(service, confirmationService, dialogService)
+        {
+            _taxRateService = service;
+        }
+
+        public async Task InitializeAsync(DateTime date)
+        {
+            var items = await _taxRateService.GetActiveForDateAsync(date);
+            Items.Clear();
+            foreach (var item in items)
+                Items.Add(item);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose `GetActiveForDateAsync` in `ITaxRateService`
- implement the filter logic in `TaxRateService`
- introduce `TaxRateSelectorViewModel` for date-based loading
- update `NewProductDialogViewModel` to use the new selector and pass `DateTime.Today`
- log the agent updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68809b7357648322b436975cbc0aa93b