### PR TITLE
Add inline PaymentMethod creation

### DIFF
--- a/Startup/NewPaymentMethodDialogService.cs
+++ b/Startup/NewPaymentMethodDialogService.cs
@@ -1,0 +1,20 @@
+using Facturon.Domain.Entities;
+using Facturon.Services;
+using Facturon.App.ViewModels.Dialogs;
+using Facturon.App.Views.Dialogs;
+
+namespace Facturon.App
+{
+    public class NewPaymentMethodDialogService : INewEntityDialogService<PaymentMethod>
+    {
+        public PaymentMethod? ShowDialog()
+        {
+            var dialog = new NewPaymentMethodDialog();
+            var vm = new NewPaymentMethodDialogViewModel();
+            dialog.DataContext = vm;
+            vm.CloseRequested += m => dialog.DialogResult = m != null;
+            var result = dialog.ShowDialog();
+            return result == true ? vm.Method : null;
+        }
+    }
+}

--- a/Startup/StartupOrchestrator.cs
+++ b/Startup/StartupOrchestrator.cs
@@ -57,6 +57,7 @@ namespace Facturon.App
                     services.AddSingleton<INewEntityDialogService<Unit>, NewUnitDialogService>();
                     services.AddSingleton<INewEntityDialogService<TaxRate>, NewTaxRateDialogService>();
                     services.AddSingleton<INewEntityDialogService<ProductGroup>, NewProductGroupDialogService>();
+                    services.AddSingleton<INewEntityDialogService<PaymentMethod>, NewPaymentMethodDialogService>();
 
                     services.AddSingleton<MainWindow>();
                     services.AddTransient<InvoiceListViewModel>();

--- a/ViewModels/Dialogs/NewPaymentMethodDialogViewModel.cs
+++ b/ViewModels/Dialogs/NewPaymentMethodDialogViewModel.cs
@@ -1,0 +1,48 @@
+using System;
+using Facturon.Domain.Entities;
+
+namespace Facturon.App.ViewModels.Dialogs
+{
+    public class NewPaymentMethodDialogViewModel : BaseViewModel
+    {
+        public PaymentMethod Method { get; } = new PaymentMethod
+        {
+            Name = string.Empty
+        };
+
+        private string? _description;
+        public string? Description
+        {
+            get => _description;
+            set
+            {
+                if (_description != value)
+                {
+                    _description = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public RelayCommand SaveCommand { get; }
+        public RelayCommand CancelCommand { get; }
+
+        public event Action<PaymentMethod?>? CloseRequested;
+
+        public NewPaymentMethodDialogViewModel()
+        {
+            SaveCommand = new RelayCommand(Save, CanSave);
+            CancelCommand = new RelayCommand(() => CloseRequested?.Invoke(null));
+        }
+
+        private bool CanSave()
+        {
+            return !string.IsNullOrWhiteSpace(Method.Name);
+        }
+
+        private void Save()
+        {
+            CloseRequested?.Invoke(Method);
+        }
+    }
+}

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -8,6 +8,9 @@ namespace Facturon.App.ViewModels
     public class MainViewModel : BaseViewModel
     {
         private readonly IInvoiceService _invoiceService;
+        private readonly IPaymentMethodService _paymentMethodService;
+        private readonly IConfirmationDialogService _confirmationService;
+        private readonly INewEntityDialogService<PaymentMethod> _paymentMethodDialogService;
 
         public InvoiceListViewModel InvoiceList { get; }
         public InvoiceDetailViewModel InvoiceDetail { get; }
@@ -44,10 +47,17 @@ namespace Facturon.App.ViewModels
         public RelayCommand NewInvoiceCommand { get; }
         public RelayCommand DeleteInvoiceCommand { get; }
 
-        public MainViewModel(IInvoiceService invoiceService)
+        public MainViewModel(
+            IInvoiceService invoiceService,
+            IPaymentMethodService paymentMethodService,
+            IConfirmationDialogService confirmationService,
+            INewEntityDialogService<PaymentMethod> paymentMethodDialogService)
         {
             Debug.WriteLine("MainViewModel created");
             _invoiceService = invoiceService;
+            _paymentMethodService = paymentMethodService;
+            _confirmationService = confirmationService;
+            _paymentMethodDialogService = paymentMethodDialogService;
             InvoiceList = new InvoiceListViewModel(invoiceService);
             InvoiceList.PropertyChanged += (s, e) =>
             {
@@ -55,7 +65,12 @@ namespace Facturon.App.ViewModels
                     OnPropertyChanged(nameof(SelectedInvoice));
             };
 
-            InvoiceDetail = new InvoiceDetailViewModel(invoiceService, this);
+            InvoiceDetail = new InvoiceDetailViewModel(
+                invoiceService,
+                _paymentMethodService,
+                _confirmationService,
+                _paymentMethodDialogService,
+                this);
 
             OpenInvoiceCommand = new RelayCommand(OpenSelected, CanOpenSelected);
             CloseDetailCommand = new RelayCommand(CloseDetail, () => DetailVisible);

--- a/ViewModels/PaymentMethodSelectorViewModel.cs
+++ b/ViewModels/PaymentMethodSelectorViewModel.cs
@@ -1,0 +1,16 @@
+using Facturon.Domain.Entities;
+using Facturon.Services;
+
+namespace Facturon.App.ViewModels
+{
+    public class PaymentMethodSelectorViewModel : EditableComboWithAddViewModel<PaymentMethod>
+    {
+        public PaymentMethodSelectorViewModel(
+            IPaymentMethodService service,
+            IConfirmationDialogService confirmationService,
+            INewEntityDialogService<PaymentMethod> dialogService)
+            : base(service, confirmationService, dialogService)
+        {
+        }
+    }
+}

--- a/Views/Dialogs/NewPaymentMethodDialog.xaml
+++ b/Views/Dialogs/NewPaymentMethodDialog.xaml
@@ -1,0 +1,33 @@
+<Window x:Class="Facturon.App.Views.Dialogs.NewPaymentMethodDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="New Payment Method"
+        WindowStartupLocation="CenterOwner"
+        SizeToContent="WidthAndHeight"
+        WindowStyle="ToolWindow"
+        FocusManager.FocusedElement="{Binding ElementName=NameBox}">
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="200" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Name:" Grid.Row="0" Grid.Column="0" Margin="0,0,5,0" />
+        <TextBox x:Name="NameBox" Grid.Row="0" Grid.Column="1"
+                 Text="{Binding Method.Name, UpdateSourceTrigger=PropertyChanged}" />
+
+        <TextBlock Text="Description:" Grid.Row="1" Grid.Column="0" Margin="0,5,5,0" />
+        <TextBox Grid.Row="1" Grid.Column="1" Margin="0,5,0,0"
+                 Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}" />
+
+        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Right">
+            <Button Content="OK" Width="75" Margin="0,0,5,0" IsDefault="True" Command="{Binding SaveCommand}" />
+            <Button Content="Cancel" Width="75" IsCancel="True" Command="{Binding CancelCommand}" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Views/Dialogs/NewPaymentMethodDialog.xaml.cs
+++ b/Views/Dialogs/NewPaymentMethodDialog.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Facturon.App.Views.Dialogs
+{
+    public partial class NewPaymentMethodDialog : Window
+    {
+        public NewPaymentMethodDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:views="clr-namespace:Facturon.App.Views"
              mc:Ignorable="d">
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -28,6 +29,9 @@
                       Content="Prices include VAT"
                       IsChecked="{Binding IsGrossBased}"
                       Margin="0,10,0,0"/>
+            <TextBlock Text="Payment Method:" Margin="0,10,0,0" />
+            <views:EditableComboWithAdd Width="200"
+                                        DataContext="{Binding PaymentMethodSelector}" />
         </StackPanel>
         <DataGrid x:Name="ItemsGrid"
                   AutomationProperties.Name="InvoiceItems"


### PR DESCRIPTION
## Summary
- create `NewPaymentMethodDialog` view and VM
- add `PaymentMethodSelectorViewModel`
- register `NewPaymentMethodDialogService`
- hook PaymentMethod selector into invoice detail view and viewmodel
- wire new dependencies through `MainViewModel`

## Testing
- `dotnet test --no-build` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68809d6fc7bc8322b8c714a6e8b37d61