### PR TITLE
Add invoice save and cancel commands

### DIFF
--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -53,6 +53,8 @@ namespace Facturon.App.ViewModels
         public RelayCommand CloseDetailCommand { get; }
         public RelayCommand NewInvoiceCommand { get; }
         public RelayCommand DeleteInvoiceCommand { get; }
+        public RelayCommand SaveInvoiceCommand { get; }
+        public RelayCommand CancelInvoiceCommand { get; }
 
         public MainViewModel(
             IInvoiceService invoiceService,
@@ -104,6 +106,8 @@ namespace Facturon.App.ViewModels
             CloseDetailCommand = new RelayCommand(CloseDetail, () => DetailVisible);
             NewInvoiceCommand = new RelayCommand(NewInvoice);
             DeleteInvoiceCommand = new RelayCommand(DeleteSelected, CanDeleteSelected);
+            SaveInvoiceCommand = new RelayCommand(SaveInvoice, () => DetailVisible);
+            CancelInvoiceCommand = new RelayCommand(CancelInvoice, () => DetailVisible);
         }
 
         public async Task InitializeAsync()
@@ -165,6 +169,36 @@ namespace Facturon.App.ViewModels
                 InvoiceList.Invoices.Remove(InvoiceList.SelectedInvoice);
                 CloseDetail();
             }
+        }
+
+        private async void SaveInvoice()
+        {
+            if (InvoiceDetail.Invoice == null)
+                return;
+
+            if (InvoiceDetail.Invoice.Id == 0)
+            {
+                var result = await _invoiceService.CreateAsync(InvoiceDetail.Invoice);
+                if (result.Success)
+                {
+                    InvoiceList.Invoices.Add(InvoiceDetail.Invoice);
+                    SelectedInvoice = InvoiceDetail.Invoice;
+                    CloseDetail();
+                }
+            }
+            else
+            {
+                var result = await _invoiceService.UpdateAsync(InvoiceDetail.Invoice);
+                if (result.Success)
+                {
+                    CloseDetail();
+                }
+            }
+        }
+
+        private void CancelInvoice()
+        {
+            CloseDetail();
         }
     }
 }

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -15,26 +15,32 @@
             <TextBlock Text="Invoice Number:"/>
             <TextBox x:Name="InvoiceNumberBox"
                      AutomationProperties.Name="InvoiceNumber"
-                     Text="{Binding Invoice.Number}"/>
+                     Text="{Binding Invoice.Number}"
+                     IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}"/>
             <TextBlock Text="Issuer:" Margin="0,10,0,0"/>
             <TextBox x:Name="IssuerBox"
                      AutomationProperties.Name="Issuer"
-                     Text="{Binding Invoice.Issuer}"/>
+                     Text="{Binding Invoice.Issuer}"
+                     IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}"/>
             <TextBlock Text="Date:" Margin="0,10,0,0"/>
             <TextBox x:Name="InvoiceDatePicker"
                      AutomationProperties.Name="InvoiceDate"
-                     Text="{Binding Invoice.Date}"/>
+                     Text="{Binding Invoice.Date}"
+                     IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}"/>
             <CheckBox x:Name="IsGrossBasedCheckBox"
                       AutomationProperties.Name="PricesIncludeVAT"
                       Content="Prices include VAT"
                       IsChecked="{Binding IsGrossBased}"
-                      Margin="0,10,0,0"/>
+                      Margin="0,10,0,0"
+                      IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}"/>
             <TextBlock Text="Payment Method:" Margin="0,10,0,0" />
             <views:EditableComboWithAdd Width="200"
-                                        DataContext="{Binding PaymentMethodSelector}" />
+                                        DataContext="{Binding PaymentMethodSelector}"
+                                        IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}" />
         </StackPanel>
         <StackPanel Grid.Row="1" Margin="0,10,0,0">
-            <views:InvoiceItemInputView DataContext="{Binding InputRow}" />
+            <views:InvoiceItemInputView DataContext="{Binding InputRow}"
+                                        IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}" />
             <DataGrid x:Name="ItemsGrid"
                       AutomationProperties.Name="InvoiceItems"
                       ItemsSource="{Binding InvoiceItems}"
@@ -43,7 +49,8 @@
                       IsReadOnly="True"
                       SelectionUnit="FullRow"
                       Margin="0,5,0,0"
-                      PreviewKeyDown="ItemsGrid_PreviewKeyDown">
+                      PreviewKeyDown="ItemsGrid_PreviewKeyDown"
+                      IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Product"
                                         Binding="{Binding Product.Name}"/>
@@ -100,6 +107,15 @@
                     <DataGridTextColumn Header="Gross" Binding="{Binding Gross, StringFormat=F2}" />
                 </DataGrid.Columns>
             </DataGrid>
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Right">
+                <Button Content="Save"
+                        Width="75"
+                        Margin="0,0,5,0"
+                        Command="{Binding DataContext.SaveInvoiceCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+                <Button Content="Cancel"
+                        Width="75"
+                        Command="{Binding DataContext.CancelInvoiceCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+            </StackPanel>
         </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- enable invoice save/cancel actions in view model
- allow invoice details to be disabled when detail hidden
- show Save/Cancel buttons in invoice detail view

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e45954548322832a27ca7ee4cab6