### PR TITLE
Implement invoice item editing

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -211,3 +211,5 @@ Added local FocusNavigationDirection enum to Services and updated INavigationSer
 
 ## [ui_agent] Sync detail visibility on selection change
 Implemented UpdateDetailVisibility in InvoiceDetailViewModel to set MainViewModel.DetailVisible based on SelectedInvoice and refresh CloseDetailCommand when hidden.
+## [ui_agent] Enable invoice item editing
+Implemented editing support in InvoiceItemInputViewModel with BeginEdit/CommitEdit. Added UI hooks for F2 or double-click to start editing. Added service UpdateAsync tests and UI test placeholder.

--- a/Tests/Services/InvoiceItemServiceTests.cs
+++ b/Tests/Services/InvoiceItemServiceTests.cs
@@ -58,5 +58,72 @@ namespace Facturon.Tests.Services
             Assert.Equal(50m, saved.UnitPrice);
             Assert.Equal(100m, saved.Total);
         }
+
+        [Fact]
+        public async Task UpdateAsync_RecalculatesTotal_WhenInvoiceIsGrossBased()
+        {
+            var invoice = new Invoice { Id = 1, Active = true, IsGrossBased = true, Items = new List<InvoiceItem>() };
+            var existing = new InvoiceItem
+            {
+                Id = 10,
+                ProductId = 2,
+                Quantity = 1,
+                UnitPrice = 120m,
+                TaxRateId = 3,
+                TaxRateValue = 20m,
+                Product = new Product { Id = 2, Active = true, TaxRateId = 3 },
+                TaxRate = new TaxRate { Id = 3, Value = 20m },
+                Invoice = invoice
+            };
+            invoice.Items.Add(existing);
+            var product = new Product { Id = 5, Active = true, TaxRateId = 3 };
+            var rate = new TaxRate { Id = 3, Value = 20m };
+            var update = new InvoiceItem { Id = 10, InvoiceId = 1, ProductId = 5, Quantity = 2, UnitPrice = 240m };
+
+            _invoiceRepo.Setup(r => r.AsQueryable()).Returns(new List<Invoice> { invoice }.AsQueryable());
+            _productRepo.Setup(r => r.GetByIdAsync(5)).ReturnsAsync(product);
+            _taxRepo.Setup(r => r.GetByIdAsync(3)).ReturnsAsync(rate);
+            _invoiceRepo.Setup(r => r.UpdateAsync(invoice)).Returns(Task.CompletedTask);
+
+            var service = CreateService();
+            await service.UpdateAsync(update);
+
+            Assert.Equal(5, existing.ProductId);
+            Assert.Equal(240m, existing.UnitPrice);
+            Assert.Equal(400m, existing.Total);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_RecalculatesTotal_WhenInvoiceIsNetBased()
+        {
+            var invoice = new Invoice { Id = 1, Active = true, IsGrossBased = false, Items = new List<InvoiceItem>() };
+            var existing = new InvoiceItem
+            {
+                Id = 11,
+                ProductId = 2,
+                Quantity = 2,
+                UnitPrice = 50m,
+                TaxRateId = 3,
+                TaxRateValue = 20m,
+                Product = new Product { Id = 2, Active = true, TaxRateId = 3 },
+                TaxRate = new TaxRate { Id = 3, Value = 20m },
+                Invoice = invoice
+            };
+            invoice.Items.Add(existing);
+            var product = new Product { Id = 2, Active = true, TaxRateId = 3 };
+            var rate = new TaxRate { Id = 3, Value = 20m };
+            var update = new InvoiceItem { Id = 11, InvoiceId = 1, ProductId = 2, Quantity = 3, UnitPrice = 50m };
+
+            _invoiceRepo.Setup(r => r.AsQueryable()).Returns(new List<Invoice> { invoice }.AsQueryable());
+            _productRepo.Setup(r => r.GetByIdAsync(2)).ReturnsAsync(product);
+            _taxRepo.Setup(r => r.GetByIdAsync(3)).ReturnsAsync(rate);
+            _invoiceRepo.Setup(r => r.UpdateAsync(invoice)).Returns(Task.CompletedTask);
+
+            var service = CreateService();
+            await service.UpdateAsync(update);
+
+            Assert.Equal(3, existing.Quantity);
+            Assert.Equal(150m, existing.Total);
+        }
     }
 }

--- a/Tests/Ui/InvoiceUITests.cs
+++ b/Tests/Ui/InvoiceUITests.cs
@@ -46,5 +46,13 @@ namespace Facturon.Tests.Ui
             Assert.AreEqual(initialIssuer, issuerBox.Text);
             Assert.AreNotEqual(initialNet, newNet);
         }
+
+        [TestMethod]
+        public void BeginEdit_OnF2_DoesNotCrash()
+        {
+            Assert.IsNotNull(_session);
+            var grid = _session.FindElementByAccessibilityId("InvoiceItems");
+            grid.SendKeys(OpenQA.Selenium.Keys.F2);
+        }
     }
 }

--- a/Views/InvoiceDetailView.xaml.cs
+++ b/Views/InvoiceDetailView.xaml.cs
@@ -8,6 +8,8 @@ namespace Facturon.App.Views
         {
             InitializeComponent();
             ItemsGrid.PreviewKeyDown += ItemsGrid_PreviewKeyDown;
+            ItemsGrid.MouseDoubleClick += ItemsGrid_MouseDoubleClick;
+            ItemsGrid.KeyDown += ItemsGrid_KeyDown;
         }
 
         private void ItemsGrid_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
@@ -19,6 +21,23 @@ namespace Facturon.App.Views
                     e.Handled = true;
                     vm.DeleteSelectedItemCommand.Execute(null);
                 }
+            }
+        }
+
+        private void ItemsGrid_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (DataContext is ViewModels.InvoiceDetailViewModel vm && vm.SelectedInvoiceItem != null)
+            {
+                vm.InputRow.BeginEdit(vm.SelectedInvoiceItem);
+            }
+        }
+
+        private void ItemsGrid_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.F2 && DataContext is ViewModels.InvoiceDetailViewModel vm && vm.SelectedInvoiceItem != null)
+            {
+                e.Handled = true;
+                vm.InputRow.BeginEdit(vm.SelectedInvoiceItem);
             }
         }
     }


### PR DESCRIPTION
## Summary
- enable editing in InvoiceItemInputViewModel with `EditingItem` and edit helpers
- hook edit start to DataGrid double-click or F2
- cover update logic in InvoiceItemService tests
- add placeholder UI test for edit

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e5cb050c8322a1612b7bb1c5daae