### PR TITLE
Implement navigation service

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -213,3 +213,7 @@ Added local FocusNavigationDirection enum to Services and updated INavigationSer
 Implemented UpdateDetailVisibility in InvoiceDetailViewModel to set MainViewModel.DetailVisible based on SelectedInvoice and refresh CloseDetailCommand when hidden.
 ## [ui_agent] Enable invoice item editing
 Implemented editing support in InvoiceItemInputViewModel with BeginEdit/CommitEdit. Added UI hooks for F2 or double-click to start editing. Added service UpdateAsync tests and UI test placeholder.
+## [orchestrator_agent] Implement Navigation Service
+- Added NavigationService with MoveFocus method using Keyboard and TraversalRequest.
+- Registered INavigationService in StartupOrchestrator.
+- Replaced direct Focus calls in views with NavigationService usage.

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -1,0 +1,14 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Facturon.Services
+{
+    public class NavigationService : INavigationService
+    {
+        public void MoveFocus(FocusNavigationDirection direction)
+        {
+            Keyboard.FocusedElement?.MoveFocus(
+                new TraversalRequest((System.Windows.Input.FocusNavigationDirection)direction));
+        }
+    }
+}

--- a/Startup/StartupOrchestrator.cs
+++ b/Startup/StartupOrchestrator.cs
@@ -59,6 +59,8 @@ namespace Facturon.App
                     services.AddSingleton<INewEntityDialogService<ProductGroup>, NewProductGroupDialogService>();
                     services.AddSingleton<INewEntityDialogService<PaymentMethod>, NewPaymentMethodDialogService>();
 
+                    services.AddSingleton<INavigationService, NavigationService>();
+
                     services.AddSingleton<MainWindow>();
                     services.AddTransient<InvoiceListViewModel>();
                     services.AddTransient<InvoiceDetailViewModel>();

--- a/Views/InvoiceListView.xaml.cs
+++ b/Views/InvoiceListView.xaml.cs
@@ -1,5 +1,8 @@
 using System.Windows.Controls;
 using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using Facturon.Services;
+using Facturon.App;
 
 namespace Facturon.App.Views
 {
@@ -14,7 +17,8 @@ namespace Facturon.App.Views
         {
             if (InvoiceList.Items.Count > 0 && InvoiceList.SelectedIndex == -1)
                 InvoiceList.SelectedIndex = 0;
-            InvoiceList.Focus();
+            var nav = ((App)Application.Current).Host?.Services.GetRequiredService<INavigationService>();
+            nav?.MoveFocus(FocusNavigationDirection.First);
         }
     }
 }

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -1,4 +1,7 @@
 using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using Facturon.Services;
+using Facturon.App;
 
 namespace Facturon.App.Views
 {
@@ -13,7 +16,8 @@ namespace Facturon.App.Views
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
-            InvoiceListHost.InvoiceList.Focus();
+            var nav = ((App)Application.Current).Host?.Services.GetRequiredService<INavigationService>();
+            nav?.MoveFocus(FocusNavigationDirection.First);
         }
 
         private void Window_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)


### PR DESCRIPTION
## Summary
- add `NavigationService` to move focus relative to the current element
- register `INavigationService` in `StartupOrchestrator`
- use `INavigationService` in `MainWindow` and `InvoiceListView`
- document changes in `PROMPT_LOG`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e8213a4483228824f02ec9cafa03