### PR TITLE
Fix navigation build errors

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -222,3 +222,7 @@ Implemented editing support in InvoiceItemInputViewModel with BeginEdit/CommitEd
 - Updated all dialog views to bind Validation.Errors for inline messages.
 ## [doc_agent] Document UX updates
 - Created docs/UX.md describing new validation visuals and row styles.
+## [orchestrator_agent] Relocate NavigationService
+Moved WPF-based NavigationService implementation to Startup project and removed it from Services.
+## [ui_agent] Initialize invoice items field
+Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to satisfy nullability analysis.

--- a/Startup/NavigationService.cs
+++ b/Startup/NavigationService.cs
@@ -1,7 +1,8 @@
 using System.Windows;
 using System.Windows.Input;
+using Facturon.Services;
 
-namespace Facturon.Services
+namespace Facturon.App
 {
     public class NavigationService : INavigationService
     {

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -142,7 +142,7 @@ namespace Facturon.App.ViewModels
             }
         }
 
-        private ObservableCollection<InvoiceItemViewModel> _invoiceItems;
+        private ObservableCollection<InvoiceItemViewModel> _invoiceItems = new();
         public ObservableCollection<InvoiceItemViewModel> InvoiceItems
         {
             get => _invoiceItems;


### PR DESCRIPTION
## Summary
- move `NavigationService` implementation to `Startup` project
- initialize `_invoiceItems` collection to remove nullability warning
- log changes in `PROMPT_LOG.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880eb6a5fe48322a9c6e0d2bf765c3d