### PR TITLE
Fix navigation enum ambiguity and style warning

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -231,3 +231,9 @@ Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to
 - Added System using to ITaxRateService.
 - Moved AlternationCount setter to DataGrid style in LightTheme.xaml.
 
+## [ui_agent] Clarify DataGrid style property
+- Set ItemsControl.AlternationCount in LightTheme.xaml to avoid row style warning.
+
+## [startup_agent] Resolve FocusNavigationDirection ambiguity
+- Removed System.Windows.Input using and fully qualified references in NavigationService.
+

--- a/Startup/NavigationService.cs
+++ b/Startup/NavigationService.cs
@@ -1,5 +1,4 @@
 using System.Windows;
-using System.Windows.Input;
 using Facturon.Services;
 
 namespace Facturon.App
@@ -8,8 +7,9 @@ namespace Facturon.App
     {
         public void MoveFocus(FocusNavigationDirection direction)
         {
-            Keyboard.FocusedElement?.MoveFocus(
-                new TraversalRequest((System.Windows.Input.FocusNavigationDirection)direction));
+            System.Windows.Input.Keyboard.FocusedElement?.MoveFocus(
+                new System.Windows.Input.TraversalRequest(
+                    (System.Windows.Input.FocusNavigationDirection)direction));
         }
     }
 }

--- a/Themes/LightTheme.xaml
+++ b/Themes/LightTheme.xaml
@@ -31,7 +31,7 @@
     <SolidColorBrush x:Key="RowHighlight" Color="#FFE6F7FF" />
     <!-- Apply alternating row colors -->
     <Style TargetType="DataGrid">
-        <Setter Property="AlternationCount" Value="2" />
+        <Setter Property="ItemsControl.AlternationCount" Value="2" />
     </Style>
 
     <Style TargetType="DataGridRow">


### PR DESCRIPTION
## Summary
- clarify `DataGrid` alternating row setting in LightTheme
- fully qualify WPF types in `NavigationService`
- log prompt details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880f08e62088322a59580ebc698fe5f