### PR TITLE
Fix DB init when Products table outdated

### DIFF
--- a/Data/DbInitializer.cs
+++ b/Data/DbInitializer.cs
@@ -33,7 +33,8 @@ namespace Facturon.Data
                     await db.Database.EnsureCreatedAsync();
                 }
 
-                if (!await ColumnExistsAsync(db, "InvoiceItems", "TaxRateValue"))
+                if (!await ColumnExistsAsync(db, "InvoiceItems", "TaxRateValue")
+                    || !await ColumnExistsAsync(db, "Products", "NetUnitPrice"))
                 {
                     logger.LogWarning("Database schema outdated. Recreating database...");
                     await db.Database.EnsureDeletedAsync();


### PR DESCRIPTION
## Summary
- recreate database if `NetUnitPrice` column is missing

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880f79106e48322b857affbdee27a27