### PR TITLE
Add EF Core migration initialization

### DIFF
--- a/Data/DbInitializer.cs
+++ b/Data/DbInitializer.cs
@@ -21,24 +21,15 @@ namespace Facturon.Data
                 var db = scope.ServiceProvider.GetRequiredService<FacturonDbContext>();
 
 
-                logger.LogInformation("Checking for pending migrations...");
-                if (db.Database.GetMigrations().Any())
-                {
-                    logger.LogInformation("Running EF Core migrations...");
-                    await db.Database.MigrateAsync();
-                }
-                else
-                {
-                    logger.LogInformation("No migrations found. Ensuring database created...");
-                    await db.Database.EnsureCreatedAsync();
-                }
+                logger.LogInformation("Applying EF Core migrations...");
+                await db.Database.MigrateAsync();
 
                 if (!await ColumnExistsAsync(db, "InvoiceItems", "TaxRateValue")
                     || !await ColumnExistsAsync(db, "Products", "NetUnitPrice"))
                 {
                     logger.LogWarning("Database schema outdated. Recreating database...");
                     await db.Database.EnsureDeletedAsync();
-                    await db.Database.EnsureCreatedAsync();
+                    await db.Database.MigrateAsync();
                 }
 
                 logger.LogInformation("Database ready.");

--- a/Data/Facturon.Data.csproj
+++ b/Data/Facturon.Data.csproj
@@ -9,5 +9,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
     <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Migrations\**\*.cs" Link="Migrations\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/Migrations/20240101000000_InitialCreate.cs
+++ b/Migrations/20240101000000_InitialCreate.cs
@@ -1,0 +1,302 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Facturon.Data.Migrations
+{
+    public partial class InitialCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PaymentMethods",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(nullable: false),
+                    Active = table.Column<bool>(nullable: false, defaultValue: true),
+                    DateCreated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    DateUpdated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PaymentMethods", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProductGroups",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(nullable: false),
+                    Active = table.Column<bool>(nullable: false, defaultValue: true),
+                    DateCreated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    DateUpdated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProductGroups", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Suppliers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(nullable: false),
+                    TaxNumber = table.Column<string>(nullable: false),
+                    Address = table.Column<string>(nullable: false),
+                    Active = table.Column<bool>(nullable: false, defaultValue: true),
+                    DateCreated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    DateUpdated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Suppliers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TaxRates",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Code = table.Column<string>(nullable: false),
+                    Value = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    ValidFrom = table.Column<DateTime>(nullable: false),
+                    ValidTo = table.Column<DateTime>(nullable: false),
+                    Active = table.Column<bool>(nullable: false, defaultValue: true),
+                    DateCreated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    DateUpdated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TaxRates", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Units",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(nullable: false),
+                    ShortName = table.Column<string>(nullable: false),
+                    Active = table.Column<bool>(nullable: false, defaultValue: true),
+                    DateCreated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    DateUpdated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Units", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Products",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(nullable: false),
+                    UnitId = table.Column<int>(nullable: false),
+                    ProductGroupId = table.Column<int>(nullable: false),
+                    TaxRateId = table.Column<int>(nullable: false),
+                    NetUnitPrice = table.Column<decimal>(type: "decimal(18,2)", nullable: false, defaultValue: 0m),
+                    Active = table.Column<bool>(nullable: false, defaultValue: true),
+                    DateCreated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    DateUpdated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Products", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Products_ProductGroups_ProductGroupId",
+                        column: x => x.ProductGroupId,
+                        principalTable: "ProductGroups",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Products_TaxRates_TaxRateId",
+                        column: x => x.TaxRateId,
+                        principalTable: "TaxRates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Products_Units_UnitId",
+                        column: x => x.UnitId,
+                        principalTable: "Units",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Invoices",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Date = table.Column<DateTime>(nullable: false),
+                    Number = table.Column<string>(nullable: false),
+                    Issuer = table.Column<string>(nullable: false),
+                    SupplierId = table.Column<int>(nullable: false),
+                    PaymentMethodId = table.Column<int>(nullable: false),
+                    IsGrossBased = table.Column<bool>(nullable: false, defaultValue: false),
+                    Active = table.Column<bool>(nullable: false, defaultValue: true),
+                    DateCreated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    DateUpdated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Invoices", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Invoices_PaymentMethods_PaymentMethodId",
+                        column: x => x.PaymentMethodId,
+                        principalTable: "PaymentMethods",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Invoices_Suppliers_SupplierId",
+                        column: x => x.SupplierId,
+                        principalTable: "Suppliers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "InvoiceItems",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    InvoiceId = table.Column<int>(nullable: false),
+                    ProductId = table.Column<int>(nullable: false),
+                    Quantity = table.Column<decimal>(nullable: false),
+                    UnitPrice = table.Column<decimal>(nullable: false),
+                    Total = table.Column<decimal>(nullable: false),
+                    TaxRateId = table.Column<int>(nullable: false),
+                    TaxRateValue = table.Column<decimal>(type: "decimal(18,2)", nullable: false, defaultValue: 0m),
+                    Active = table.Column<bool>(nullable: false, defaultValue: true),
+                    DateCreated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    DateUpdated = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InvoiceItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InvoiceItems_Invoices_InvoiceId",
+                        column: x => x.InvoiceId,
+                        principalTable: "Invoices",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_InvoiceItems_Products_ProductId",
+                        column: x => x.ProductId,
+                        principalTable: "Products",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_InvoiceItems_TaxRates_TaxRateId",
+                        column: x => x.TaxRateId,
+                        principalTable: "TaxRates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invoices_Number",
+                table: "Invoices",
+                column: "Number",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invoices_PaymentMethodId",
+                table: "Invoices",
+                column: "PaymentMethodId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invoices_SupplierId",
+                table: "Invoices",
+                column: "SupplierId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvoiceItems_InvoiceId",
+                table: "InvoiceItems",
+                column: "InvoiceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvoiceItems_ProductId",
+                table: "InvoiceItems",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvoiceItems_TaxRateId",
+                table: "InvoiceItems",
+                column: "TaxRateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_Name",
+                table: "Products",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_ProductGroupId",
+                table: "Products",
+                column: "ProductGroupId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_TaxRateId",
+                table: "Products",
+                column: "TaxRateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_UnitId",
+                table: "Products",
+                column: "UnitId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Suppliers_TaxNumber",
+                table: "Suppliers",
+                column: "TaxNumber",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaxRates_Code",
+                table: "TaxRates",
+                column: "Code",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaymentMethods_Name",
+                table: "PaymentMethods",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProductGroups_Name",
+                table: "ProductGroups",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Units_ShortName",
+                table: "Units",
+                column: "ShortName",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "InvoiceItems");
+            migrationBuilder.DropTable(name: "Invoices");
+            migrationBuilder.DropTable(name: "Products");
+            migrationBuilder.DropTable(name: "PaymentMethods");
+            migrationBuilder.DropTable(name: "Suppliers");
+            migrationBuilder.DropTable(name: "ProductGroups");
+            migrationBuilder.DropTable(name: "TaxRates");
+            migrationBuilder.DropTable(name: "Units");
+        }
+    }
+}

--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -240,3 +240,8 @@ Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to
 
 ## [startup_agent] Cast Keyboard.FocusedElement
 - Cast Keyboard.FocusedElement to UIElement before calling MoveFocus to satisfy .NET focus API.
+
+## [db_agent] Add EF Core migrations support and restructure initializer
+- Added Microsoft.EntityFrameworkCore.Design to Data project and included Migrations folder.
+- Created initial migration defining tables in dependency order.
+- Updated DbInitializer to always apply migrations.


### PR DESCRIPTION
## Summary
- include EF Core Design dependency and compile migrations
- create initial migration with ordered table creation
- run migrations automatically in `DbInitializer`
- log agent actions

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880fb3280788322a021387586050235