### PR TITLE
Add DisplayMemberPath to EditableComboWithAdd

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -247,3 +247,6 @@ Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to
 
 ## [db_agent] Restore EnsureCreated fallback
 - DbInitializer now checks for migrations and calls EnsureCreated when none exist, preventing missing table errors.
+## [ui_agent] Add DisplayMemberPath support to EditableComboWithAdd
+- Introduced DisplayMemberPath dependency property and bound ComboBox.DisplayMemberPath.
+- Specified DisplayMemberPath on dialog views using EditableComboWithAdd.

--- a/Views/EditableComboWithAdd.xaml
+++ b/Views/EditableComboWithAdd.xaml
@@ -7,7 +7,8 @@
                   IsEditable="True"
                   ItemsSource="{Binding Items}"
                   Text="{Binding Input, UpdateSourceTrigger=PropertyChanged}"
-                  SelectedItem="{Binding SelectedItem}" />
+                  SelectedItem="{Binding SelectedItem}"
+                  DisplayMemberPath="{Binding DisplayMemberPath, RelativeSource={RelativeSource AncestorType=UserControl}}" />
         <Button Content="Add" Margin="5,0,0,0" />
     </StackPanel>
 </UserControl>

--- a/Views/EditableComboWithAdd.xaml.cs
+++ b/Views/EditableComboWithAdd.xaml.cs
@@ -7,6 +7,15 @@ namespace Facturon.App.Views
 {
     public partial class EditableComboWithAdd : UserControl
     {
+        public static readonly DependencyProperty DisplayMemberPathProperty = DependencyProperty.Register(
+            nameof(DisplayMemberPath), typeof(string), typeof(EditableComboWithAdd), new PropertyMetadata(null));
+
+        public string DisplayMemberPath
+        {
+            get => (string)GetValue(DisplayMemberPathProperty);
+            set => SetValue(DisplayMemberPathProperty, value);
+        }
+
         public EditableComboWithAdd()
         {
             InitializeComponent();

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -36,7 +36,8 @@
             <TextBlock Text="Payment Method:" Margin="0,10,0,0" />
             <views:EditableComboWithAdd Width="200"
                                         DataContext="{Binding PaymentMethodSelector}"
-                                        IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}" />
+                                        IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}"
+                                        DisplayMemberPath="Name" />
         </StackPanel>
         <StackPanel Grid.Row="1" Margin="0,10,0,0">
             <views:InvoiceItemInputView DataContext="{Binding InputRow}"

--- a/Views/InvoiceItemInputView.xaml
+++ b/Views/InvoiceItemInputView.xaml
@@ -4,16 +4,19 @@
              xmlns:views="clr-namespace:Facturon.App.Views">
     <StackPanel Orientation="Horizontal">
         <views:EditableComboWithAdd Width="200"
-                                    DataContext="{Binding ProductSelector}" />
+                                    DataContext="{Binding ProductSelector}"
+                                    DisplayMemberPath="Name" />
         <TextBox Width="60"
                  Margin="5,0,0,0"
                  Text="{Binding Quantity, UpdateSourceTrigger=PropertyChanged}" />
         <views:EditableComboWithAdd Width="100"
                                     Margin="5,0,0,0"
-                                    DataContext="{Binding UnitSelector}" />
+                                    DataContext="{Binding UnitSelector}"
+                                    DisplayMemberPath="Name" />
         <views:EditableComboWithAdd Width="100"
                                     Margin="5,0,0,0"
-                                    DataContext="{Binding TaxRateSelector}" />
+                                    DataContext="{Binding TaxRateSelector}"
+                                    DisplayMemberPath="Code" />
         <TextBox Width="80"
                  Margin="5,0,0,0"
                  Text="{Binding NetUnitPrice, UpdateSourceTrigger=PropertyChanged}" />

--- a/Views/NewProductDialog.xaml
+++ b/Views/NewProductDialog.xaml
@@ -12,13 +12,16 @@
         <TextBox x:Name="NameBox" Width="200" Text="{Binding Product.Name, UpdateSourceTrigger=PropertyChanged}" />
         <TextBlock Text="Unit:" Margin="0,5,0,0"/>
         <views:EditableComboWithAdd Width="200"
-                                    DataContext="{Binding UnitSelector}" />
+                                    DataContext="{Binding UnitSelector}"
+                                    DisplayMemberPath="Name" />
         <TextBlock Text="Tax Rate:" Margin="0,5,0,0"/>
         <views:EditableComboWithAdd Width="200"
-                                    DataContext="{Binding TaxRateSelector}" />
+                                    DataContext="{Binding TaxRateSelector}"
+                                    DisplayMemberPath="Code" />
         <TextBlock Text="Product Group:" Margin="0,5,0,0"/>
         <views:EditableComboWithAdd Width="200"
-                                    DataContext="{Binding ProductGroupSelector}" />
+                                    DataContext="{Binding ProductGroupSelector}"
+                                    DisplayMemberPath="Name" />
         <TextBlock Text="Net Unit Price:" Margin="0,5,0,0"/>
         <TextBox Width="200" Text="{Binding NetUnitPrice, UpdateSourceTrigger=PropertyChanged}" />
         <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Right">


### PR DESCRIPTION
## Summary
- extend `EditableComboWithAdd` with a `DisplayMemberPath` dependency property
- bind `ComboBox.DisplayMemberPath` to the new property
- specify `DisplayMemberPath` for all usages of `EditableComboWithAdd`
- log these changes in `PROMPT_LOG.md`

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
files=['Views/EditableComboWithAdd.xaml','Views/NewProductDialog.xaml','Views/InvoiceItemInputView.xaml','Views/InvoiceDetailView.xaml']
for f in files:
    ET.parse(f)
    print(f, 'OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68812df70a2c8322b56675afa5edbc59