### PR TITLE
Implement commands for InvoiceDetailView

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -267,3 +267,7 @@ Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to
 
 ## [ui_agent] Add key bindings for item input
 - Bound Enter to AddCommand and Escape to ClearCommand in InvoiceItemInputView. Removed PreviewKeyDown handler.
+
+## [ui_agent] Bind item commands in InvoiceDetailView
+- Added BeginEditItemCommand and InputBindings for Delete, F2 and double-click.
+- Removed code-behind event handlers.

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -37,12 +37,14 @@ namespace Facturon.App.ViewModels
                     _selectedInvoiceItem = value;
                     OnPropertyChanged();
                     DeleteSelectedItemCommand.RaiseCanExecuteChanged();
+                    BeginEditItemCommand.RaiseCanExecuteChanged();
                 }
             }
         }
 
         private InvoiceItemViewModel? _selectedInvoiceItem;
         public RelayCommand DeleteSelectedItemCommand { get; }
+        public RelayCommand BeginEditItemCommand { get; }
 
         public InvoiceDetailViewModel(
             IInvoiceService invoiceService,
@@ -90,6 +92,7 @@ namespace Facturon.App.ViewModels
             InputRow.ItemReadyToAdd += InputRowOnItemReadyToAdd;
 
             DeleteSelectedItemCommand = new RelayCommand(DeleteSelectedItem, CanDeleteSelectedItem);
+            BeginEditItemCommand = new RelayCommand(BeginEditItem, CanBeginEditItem);
 
             InvoiceItems = new ObservableCollection<InvoiceItemViewModel>();
             _mainViewModel.PropertyChanged += MainViewModel_PropertyChanged;
@@ -268,6 +271,16 @@ namespace Facturon.App.ViewModels
             vm.RecalculateAmounts(IsGrossBased);
             InvoiceItems.Add(vm);
             _ = RecalculateTotalsAsync();
+        }
+
+        private bool CanBeginEditItem() => SelectedInvoiceItem != null;
+
+        private void BeginEditItem()
+        {
+            if (SelectedInvoiceItem != null)
+            {
+                InputRow.BeginEdit(SelectedInvoiceItem);
+            }
         }
 
         private bool CanDeleteSelectedItem() => SelectedInvoiceItem != null;

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -49,9 +49,13 @@
                       AutoGenerateColumns="False"
                       IsReadOnly="True"
                       SelectionUnit="FullRow"
-                      Margin="0,5,0,0"
-                      PreviewKeyDown="ItemsGrid_PreviewKeyDown"
+                     Margin="0,5,0,0"
                       IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}">
+                <DataGrid.InputBindings>
+                    <KeyBinding Key="Delete" Command="{Binding DeleteSelectedItemCommand}" />
+                    <KeyBinding Key="F2" Command="{Binding BeginEditItemCommand}" />
+                    <MouseBinding MouseAction="LeftDoubleClick" Command="{Binding BeginEditItemCommand}" />
+                </DataGrid.InputBindings>
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Product"
                                         Binding="{Binding Product.Name}"/>

--- a/Views/InvoiceDetailView.xaml.cs
+++ b/Views/InvoiceDetailView.xaml.cs
@@ -7,38 +7,6 @@ namespace Facturon.App.Views
         public InvoiceDetailView()
         {
             InitializeComponent();
-            ItemsGrid.PreviewKeyDown += ItemsGrid_PreviewKeyDown;
-            ItemsGrid.MouseDoubleClick += ItemsGrid_MouseDoubleClick;
-            ItemsGrid.KeyDown += ItemsGrid_KeyDown;
-        }
-
-        private void ItemsGrid_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
-        {
-            if (e.Key == System.Windows.Input.Key.Delete && DataContext is ViewModels.InvoiceDetailViewModel vm)
-            {
-                if (vm.DeleteSelectedItemCommand.CanExecute(null))
-                {
-                    e.Handled = true;
-                    vm.DeleteSelectedItemCommand.Execute(null);
-                }
-            }
-        }
-
-        private void ItemsGrid_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            if (DataContext is ViewModels.InvoiceDetailViewModel vm && vm.SelectedInvoiceItem != null)
-            {
-                vm.InputRow.BeginEdit(vm.SelectedInvoiceItem);
-            }
-        }
-
-        private void ItemsGrid_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
-        {
-            if (e.Key == System.Windows.Input.Key.F2 && DataContext is ViewModels.InvoiceDetailViewModel vm && vm.SelectedInvoiceItem != null)
-            {
-                e.Handled = true;
-                vm.InputRow.BeginEdit(vm.SelectedInvoiceItem);
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `BeginEditItemCommand` and raise can-execute on selection changes
- hook `BeginEditItemCommand` and existing delete command via `InputBindings`
- remove code-behind event handlers for DataGrid
- log the work in `PROMPT_LOG`

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688173a7566883228b99eb6226d9bdbf