### PR TITLE
Add initial focus and exit commands

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -271,3 +271,8 @@ Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to
 ## [ui_agent] Bind item commands in InvoiceDetailView
 - Added BeginEditItemCommand and InputBindings for Delete, F2 and double-click.
 - Removed code-behind event handlers.
+
+## [ui_agent] Add window Loaded and Exit commands
+- Introduced LoadedCommand and ExitCommand in MainViewModel.
+- Bound LoadedCommand via attached behavior and Escape key via InputBinding in MainWindow.
+- Removed MainWindow code-behind logic.

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Windows;
 using Facturon.Domain.Entities;
 using Facturon.Services;
 
@@ -18,6 +19,7 @@ namespace Facturon.App.ViewModels
         private readonly INewEntityDialogService<Unit> _unitDialogService;
         private readonly INewEntityDialogService<TaxRate> _taxDialogService;
         private readonly IInvoiceItemService _invoiceItemService;
+        private readonly INavigationService _navigationService;
 
         public InvoiceListViewModel InvoiceList { get; }
         public InvoiceDetailViewModel InvoiceDetail { get; }
@@ -55,6 +57,8 @@ namespace Facturon.App.ViewModels
         public RelayCommand DeleteInvoiceCommand { get; }
         public RelayCommand SaveInvoiceCommand { get; }
         public RelayCommand CancelInvoiceCommand { get; }
+        public RelayCommand LoadedCommand { get; }
+        public RelayCommand ExitCommand { get; }
 
         public MainViewModel(
             IInvoiceService invoiceService,
@@ -64,6 +68,7 @@ namespace Facturon.App.ViewModels
             ITaxRateService taxRateService,
             IInvoiceItemService invoiceItemService,
             IConfirmationDialogService confirmationService,
+            INavigationService navigationService,
             INewEntityDialogService<PaymentMethod> paymentMethodDialogService,
             INewEntityDialogService<Product> productDialogService,
             INewEntityDialogService<Unit> unitDialogService,
@@ -77,6 +82,7 @@ namespace Facturon.App.ViewModels
             _taxRateService = taxRateService;
             _invoiceItemService = invoiceItemService;
             _confirmationService = confirmationService;
+            _navigationService = navigationService;
             _paymentMethodDialogService = paymentMethodDialogService;
             _productDialogService = productDialogService;
             _unitDialogService = unitDialogService;
@@ -108,6 +114,8 @@ namespace Facturon.App.ViewModels
             DeleteInvoiceCommand = new RelayCommand(DeleteSelected, CanDeleteSelected);
             SaveInvoiceCommand = new RelayCommand(SaveInvoice, () => DetailVisible);
             CancelInvoiceCommand = new RelayCommand(CancelInvoice, () => DetailVisible);
+            LoadedCommand = new RelayCommand(() => _navigationService.MoveFocus(FocusNavigationDirection.First));
+            ExitCommand = new RelayCommand(ExecuteExitAsync);
         }
 
         public async Task InitializeAsync()
@@ -199,6 +207,13 @@ namespace Facturon.App.ViewModels
         private void CancelInvoice()
         {
             CloseDetail();
+        }
+
+        private async void ExecuteExitAsync()
+        {
+            var confirm = await _confirmationService.ConfirmAsync("Exit", "Do you really want to exit?");
+            if (confirm)
+                Application.Current?.MainWindow?.Close();
         }
     }
 }

--- a/Views/Behaviors/LoadedBehavior.cs
+++ b/Views/Behaviors/LoadedBehavior.cs
@@ -1,0 +1,36 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Facturon.App.Views.Behaviors
+{
+    public static class LoadedBehavior
+    {
+        public static readonly DependencyProperty CommandProperty = DependencyProperty.RegisterAttached(
+            "Command",
+            typeof(ICommand),
+            typeof(LoadedBehavior),
+            new PropertyMetadata(null, OnCommandChanged));
+
+        public static ICommand? GetCommand(DependencyObject obj) => (ICommand?)obj.GetValue(CommandProperty);
+
+        public static void SetCommand(DependencyObject obj, ICommand? value) => obj.SetValue(CommandProperty, value);
+
+        private static void OnCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is FrameworkElement fe)
+            {
+                fe.Loaded -= OnLoaded;
+                if (e.NewValue is ICommand)
+                    fe.Loaded += OnLoaded;
+            }
+        }
+
+        private static void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            var fe = (FrameworkElement)sender;
+            var command = GetCommand(fe);
+            if (command?.CanExecute(null) == true)
+                command.Execute(null);
+        }
+    }
+}

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -3,11 +3,11 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Facturon.App.Views"
         xmlns:viewModels="clr-namespace:Facturon.App.ViewModels"
+        xmlns:behaviors="clr-namespace:Facturon.App.Views.Behaviors"
         Title="Facturon"
         Height="450"
         Width="800"
-        Loaded="Window_Loaded"
-        PreviewKeyDown="Window_PreviewKeyDown">
+        behaviors:LoadedBehavior.Command="{Binding LoadedCommand}">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <DataTemplate DataType="{x:Type viewModels:InvoiceListViewModel}">
@@ -18,6 +18,7 @@
         <KeyBinding Key="Enter" Command="{Binding OpenInvoiceCommand}"/>
         <KeyBinding Key="Insert" Command="{Binding NewInvoiceCommand}"/>
         <KeyBinding Key="Delete" Command="{Binding DeleteInvoiceCommand}"/>
+        <KeyBinding Key="Escape" Command="{Binding ExitCommand}"/>
     </Window.InputBindings>
     <Grid>
         <Grid.ColumnDefinitions>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -1,6 +1,4 @@
 using System.Windows;
-using Microsoft.Extensions.DependencyInjection;
-using Facturon.Services;
 using Facturon.App;
 
 namespace Facturon.App.Views
@@ -10,26 +8,6 @@ namespace Facturon.App.Views
         public MainWindow()
         {
             InitializeComponent();
-            Loaded += Window_Loaded;
-            PreviewKeyDown += Window_PreviewKeyDown;
-        }
-
-        private void Window_Loaded(object sender, RoutedEventArgs e)
-        {
-            var nav = ((App)Application.Current).Host?.Services.GetRequiredService<INavigationService>();
-            nav?.MoveFocus(FocusNavigationDirection.First);
-        }
-
-        private void Window_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
-        {
-            if (e.Key == System.Windows.Input.Key.Escape)
-            {
-                e.Handled = true;
-                var dlg = new ConfirmExitWindow { Owner = this };
-                var result = dlg.ShowDialog();
-                if (result == true)
-                    Close();
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- support focus and exit logic via MainViewModel commands
- use new LoadedBehavior to invoke commands on load
- bind Escape key to exit in `MainWindow`
- remove code-behind for focus and exit

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881762091d08322be2f714e82af47ff