### PR TITLE
Refactor ConfirmExit dialog to MVVM

### DIFF
--- a/ViewModels/ConfirmExitViewModel.cs
+++ b/ViewModels/ConfirmExitViewModel.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Facturon.App.ViewModels
+{
+    public class ConfirmExitViewModel : BaseViewModel
+    {
+        public RelayCommand YesCommand { get; }
+        public RelayCommand NoCommand { get; }
+
+        public event Action<bool>? CloseRequested;
+
+        public ConfirmExitViewModel()
+        {
+            YesCommand = new RelayCommand(() => CloseRequested?.Invoke(true));
+            NoCommand = new RelayCommand(() => CloseRequested?.Invoke(false));
+        }
+    }
+}

--- a/Views/ConfirmExitWindow.xaml
+++ b/Views/ConfirmExitWindow.xaml
@@ -5,13 +5,15 @@
         WindowStartupLocation="CenterOwner"
         SizeToContent="WidthAndHeight"
         ResizeMode="NoResize"
-        WindowStyle="ToolWindow"
-        KeyDown="Window_KeyDown">
+        WindowStyle="ToolWindow">
+    <Window.InputBindings>
+        <KeyBinding Key="Escape" Command="{Binding YesCommand}"/>
+    </Window.InputBindings>
     <StackPanel Margin="10">
         <TextBlock Text="Do you really want to exit?" Margin="0,0,0,10"/>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button x:Name="YesButton" Content="Yes" Margin="0,0,5,0" Width="75" Click="YesButton_Click"/>
-            <Button x:Name="NoButton" Content="No" IsDefault="True" IsCancel="True" Width="75" Click="NoButton_Click"/>
+            <Button x:Name="YesButton" Content="Yes" Margin="0,0,5,0" Width="75" Command="{Binding YesCommand}"/>
+            <Button x:Name="NoButton" Content="No" IsDefault="True" IsCancel="True" Width="75" Command="{Binding NoCommand}"/>
         </StackPanel>
     </StackPanel>
 </Window>

--- a/Views/ConfirmExitWindow.xaml.cs
+++ b/Views/ConfirmExitWindow.xaml.cs
@@ -1,5 +1,5 @@
 using System.Windows;
-using System.Windows.Input;
+using Facturon.App.ViewModels;
 
 namespace Facturon.App.Views
 {
@@ -8,24 +8,9 @@ namespace Facturon.App.Views
         public ConfirmExitWindow()
         {
             InitializeComponent();
-        }
-
-        private void YesButton_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = true;
-        }
-
-        private void NoButton_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = false;
-        }
-
-        private void Window_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Escape)
-            {
-                DialogResult = true;
-            }
+            var vm = new ConfirmExitViewModel();
+            DataContext = vm;
+            vm.CloseRequested += result => DialogResult = result;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `ConfirmExitViewModel` with Yes/No commands
- bind buttons and Escape key in `ConfirmExitWindow.xaml`
- clean up code-behind to use the new view model

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
- `apt-get update` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68817b292e288322a30d7eda5b751e94