### PR TITLE
Use command binding for EditableComboWithAdd

### DIFF
--- a/ViewModels/EditableComboWithAddViewModel.cs
+++ b/ViewModels/EditableComboWithAddViewModel.cs
@@ -14,6 +14,8 @@ namespace Facturon.App.ViewModels
 
         public event Action? FocusRequested;
 
+        public RelayCommand ConfirmInputCommand { get; }
+
         public ObservableCollection<T> Items { get; } = new ObservableCollection<T>();
 
         private T? _selectedItem;
@@ -52,6 +54,12 @@ namespace Facturon.App.ViewModels
             _service = service;
             _confirmationService = confirmationService;
             _dialogService = dialogService;
+            ConfirmInputCommand = new RelayCommand(ExecuteConfirmInputAsync);
+        }
+
+        private async void ExecuteConfirmInputAsync()
+        {
+            await ConfirmInputAsync();
         }
 
         public async Task InitializeAsync()

--- a/Views/Behaviors/LostFocusBehavior.cs
+++ b/Views/Behaviors/LostFocusBehavior.cs
@@ -1,0 +1,36 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Facturon.App.Views.Behaviors
+{
+    public static class LostFocusBehavior
+    {
+        public static readonly DependencyProperty CommandProperty = DependencyProperty.RegisterAttached(
+            "Command",
+            typeof(ICommand),
+            typeof(LostFocusBehavior),
+            new PropertyMetadata(null, OnCommandChanged));
+
+        public static ICommand? GetCommand(DependencyObject obj) => (ICommand?)obj.GetValue(CommandProperty);
+
+        public static void SetCommand(DependencyObject obj, ICommand? value) => obj.SetValue(CommandProperty, value);
+
+        private static void OnCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is FrameworkElement fe)
+            {
+                fe.LostFocus -= OnLostFocus;
+                if (e.NewValue is ICommand)
+                    fe.LostFocus += OnLostFocus;
+            }
+        }
+
+        private static void OnLostFocus(object sender, RoutedEventArgs e)
+        {
+            var fe = (FrameworkElement)sender;
+            var command = GetCommand(fe);
+            if (command?.CanExecute(null) == true)
+                command.Execute(null);
+        }
+    }
+}

--- a/Views/EditableComboWithAdd.xaml
+++ b/Views/EditableComboWithAdd.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Facturon.App.Views.EditableComboWithAdd"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:behaviors="clr-namespace:Facturon.App.Views.Behaviors">
     <StackPanel Orientation="Horizontal">
         <ComboBox x:Name="Combo"
                   Width="200"
@@ -8,7 +9,12 @@
                   ItemsSource="{Binding Items}"
                   Text="{Binding Input, UpdateSourceTrigger=PropertyChanged}"
                   SelectedItem="{Binding SelectedItem}"
-                  DisplayMemberPath="{Binding DisplayMemberPath, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+                  DisplayMemberPath="{Binding DisplayMemberPath, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                  behaviors:LostFocusBehavior.Command="{Binding ConfirmInputCommand}">
+            <ComboBox.InputBindings>
+                <KeyBinding Key="Enter" Command="{Binding ConfirmInputCommand}" />
+            </ComboBox.InputBindings>
+        </ComboBox>
         <Button Content="Add" Margin="5,0,0,0" />
     </StackPanel>
 </UserControl>

--- a/Views/EditableComboWithAdd.xaml.cs
+++ b/Views/EditableComboWithAdd.xaml.cs
@@ -1,7 +1,5 @@
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
 
 namespace Facturon.App.Views
 {
@@ -19,31 +17,6 @@ namespace Facturon.App.Views
         public EditableComboWithAdd()
         {
             InitializeComponent();
-            Combo.KeyDown += Combo_KeyDown;
-            Combo.LostFocus += Combo_LostFocus;
-        }
-
-        private async void Combo_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Enter)
-            {
-                e.Handled = true;
-                await ConfirmAsync();
-            }
-        }
-
-        private async void Combo_LostFocus(object sender, RoutedEventArgs e)
-        {
-            await ConfirmAsync();
-        }
-
-        private async Task ConfirmAsync()
-        {
-            if (DataContext is null)
-                return;
-
-            dynamic vm = DataContext;
-            await vm.ConfirmInputAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `ConfirmInputCommand` to `EditableComboWithAddViewModel`
- trigger command on Enter key and lost focus in `EditableComboWithAdd`
- remove code-behind handlers and introduce new `LostFocusBehavior`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68817d3255d483228ddce59bbf84dd73