### PR TITLE
Add supplier selector to invoice detail view

### DIFF
--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -15,7 +15,7 @@
             <TextBlock Text="Invoice Number:"/>
             <TextBox x:Name="InvoiceNumberBox"
                      AutomationProperties.Name="InvoiceNumber"
-                     Text="{Binding Invoice.Number}"
+                     Text="{Binding Invoice.Number, UpdateSourceTrigger=PropertyChanged}"
                      IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}"/>
             <TextBlock Text="Issuer:" Margin="0,10,0,0"/>
             <TextBox x:Name="IssuerBox"
@@ -36,6 +36,11 @@
             <TextBlock Text="Payment Method:" Margin="0,10,0,0" />
             <views:EditableComboWithAdd Width="200"
                                         DataContext="{Binding PaymentMethodSelector}"
+                                        IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}"
+                                        DisplayMemberPath="Name" />
+            <TextBlock Text="Supplier:" Margin="0,10,0,0" />
+            <views:EditableComboWithAdd Width="200"
+                                        DataContext="{Binding SupplierSelector}"
                                         IsEnabled="{Binding DataContext.DetailVisible, RelativeSource={RelativeSource AncestorType=Window}}"
                                         DisplayMemberPath="Name" />
         </StackPanel>


### PR DESCRIPTION
## Summary
- allow instant invoice number updates by triggering binding updates on each keystroke
- include supplier selection via `EditableComboWithAdd` in the invoice detail view

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6882b7613f2083229459257899175f47