### PR TITLE
Implement invoice screen state handling

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -285,3 +285,6 @@ Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to
 ## [ui_agent] Add AddNewCommand for editable combos
 - Introduced AddNewCommand in EditableComboWithAddViewModel to directly open the entity creation dialog.
 - Bound the Add button in EditableComboWithAdd.xaml to this command.
+## [ui_agent] Introduce invoice screen states
+- Added InvoiceScreenState enum and ScreenState property in MainViewModel.
+- Updated commands and methods to switch states and control detail visibility.

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -330,12 +330,11 @@ namespace Facturon.App.ViewModels
         {
             if (_mainViewModel.SelectedInvoice != null)
             {
-                _mainViewModel.DetailVisible = true;
+                _mainViewModel.ScreenState = InvoiceScreenState.Editing;
             }
             else
             {
-                _mainViewModel.DetailVisible = false;
-                _mainViewModel.CloseDetailCommand.RaiseCanExecuteChanged();
+                _mainViewModel.ScreenState = InvoiceScreenState.Browsing;
             }
         }
     }

--- a/ViewModels/InvoiceScreenState.cs
+++ b/ViewModels/InvoiceScreenState.cs
@@ -1,0 +1,8 @@
+namespace Facturon.App.ViewModels
+{
+    public enum InvoiceScreenState
+    {
+        Browsing,
+        Editing
+    }
+}


### PR DESCRIPTION
## Summary
- add `InvoiceScreenState` enum
- track current view state in `MainViewModel`
- update commands and methods to react to state changes
- sync `InvoiceDetailViewModel` with new state

## Testing
- `dotnet build` *(fails: command skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6882bc539dfc8322b7f8d698d3636300