### PR TITLE
Update UX docs for supplier selector and screen states

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -291,3 +291,7 @@ Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to
 ## [startup_agent] Inject supplier dependencies in invoice detail
 - Updated InvoiceDetailViewModel registration to supply supplier service and dialog.
 
+
+## [doc_agent] Document supplier selector and screen states
+- Added usage notes for the supplier selector component.
+- Described browsing and editing screen states in docs/UX.md.

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -7,3 +7,13 @@
 ## Data grid rows
 - Rows alternate background colors in the light theme.
 - Selected rows highlight with a light blue shade for clarity.
+
+## Supplier selector
+- Type a supplier name in the combo box and press Enter to confirm.
+- If the name does not exist, the selector offers to create it via a dialog.
+- Use the Add button to open the creation dialog directly.
+
+## Screen states
+- Browsing mode shows the invoice list and disables detail inputs.
+- Editing mode is activated when creating or opening an invoice and enables the detail pane.
+- Save and Cancel commands switch back to Browsing mode.


### PR DESCRIPTION
## Summary
- document supplier selector usage
- explain invoice screen states
- log the doc update in PROMPT_LOG

## Testing
- `grep -n "##" -n docs/UX.md`
- `grep -n "## \[doc_agent\]" -n PROMPT_LOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6882bfe6343883228f3a169eb4932032