### PR TITLE
Handle validation failure when saving invoice

### DIFF
--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -197,23 +197,32 @@ namespace Facturon.App.ViewModels
             if (InvoiceDetail.Invoice == null)
                 return;
 
+            Result result;
+
             if (InvoiceDetail.Invoice.Id == 0)
             {
-                var result = await _invoiceService.CreateAsync(InvoiceDetail.Invoice);
+                result = await _invoiceService.CreateAsync(InvoiceDetail.Invoice);
                 if (result.Success)
                 {
                     InvoiceList.Invoices.Add(InvoiceDetail.Invoice);
                     SelectedInvoice = InvoiceDetail.Invoice;
-                    CloseDetail();
                 }
             }
             else
             {
-                var result = await _invoiceService.UpdateAsync(InvoiceDetail.Invoice);
-                if (result.Success)
-                {
-                    CloseDetail();
-                }
+                result = await _invoiceService.UpdateAsync(InvoiceDetail.Invoice);
+            }
+
+            if (result.Success)
+            {
+                CloseDetail();
+            }
+            else
+            {
+                await _confirmationService.ConfirmAsync(
+                    "Save failed",
+                    string.IsNullOrEmpty(result.Message) ? "Validation errors occurred." : result.Message);
+                ScreenState = InvoiceScreenState.Editing;
             }
         }
 


### PR DESCRIPTION
## Summary
- keep MainViewModel in editing mode when save fails
- show failure message using ConfirmationDialogService

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882c77dc62c83229238c3dae678b184