### PR TITLE
Fix new invoice payment method default

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -298,3 +298,7 @@ Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to
 
 ## [ui_agent] Fix missing Linq using
 - Added System.Linq import in MainViewModel for FirstOrDefault.
+
+## [ui_agent] Preselect payment method on new invoice
+- Set PaymentMethodSelector.SelectedItem to the first item after creating the invoice object in MainViewModel.NewInvoice.
+- Ensures default selection similar to SupplierSelector.

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -177,6 +177,7 @@ namespace Facturon.App.ViewModels
                 }
             };
             InvoiceDetail.SupplierSelector.SelectedItem = InvoiceDetail.SupplierSelector.Items.FirstOrDefault();
+            InvoiceDetail.PaymentMethodSelector.SelectedItem = InvoiceDetail.PaymentMethodSelector.Items.FirstOrDefault();
             ScreenState = InvoiceScreenState.Editing;
         }
 


### PR DESCRIPTION
## Summary
- set `PaymentMethodSelector.SelectedItem` when creating a new invoice
- log the change in PROMPT_LOG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882cd8c553483229e25db63788e6e80