### PR TITLE
Add async LoadCommand for view model init

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -302,3 +302,8 @@ Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to
 ## [ui_agent] Preselect payment method on new invoice
 - Set PaymentMethodSelector.SelectedItem to the first item after creating the invoice object in MainViewModel.NewInvoice.
 - Ensures default selection similar to SupplierSelector.
+
+## [ui_agent] Async view model loading
+- Replaced synchronous initialization with InitializeAsync in InvoiceItemInputViewModel, NewProductDialogViewModel, and InvoiceDetailViewModel.
+- Added LoadCommand properties and bound them to Loaded events in corresponding views.
+- Updated NewProductDialogService to stop calling Initialize().

--- a/Startup/NewProductDialogService.cs
+++ b/Startup/NewProductDialogService.cs
@@ -48,7 +48,6 @@ namespace Facturon.App
                 _unitDialogService,
                 _taxRateDialogService,
                 _productGroupDialogService);
-            vm.Initialize();
             dialog.DataContext = vm;
             vm.CloseRequested += p => dialog.DialogResult = p != null;
             var result = dialog.ShowDialog();

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -48,6 +48,7 @@ namespace Facturon.App.ViewModels
         private InvoiceItemViewModel? _selectedInvoiceItem;
         public RelayCommand DeleteSelectedItemCommand { get; }
         public RelayCommand BeginEditItemCommand { get; }
+        public RelayCommand LoadCommand { get; }
 
         public InvoiceDetailViewModel(
             IInvoiceService invoiceService,
@@ -84,14 +85,12 @@ namespace Facturon.App.ViewModels
                 _paymentMethodService,
                 _confirmationService,
                 _paymentMethodDialogService);
-            PaymentMethodSelector.InitializeAsync().GetAwaiter().GetResult();
             PaymentMethodSelector.PropertyChanged += PaymentMethodSelectorOnPropertyChanged;
 
             SupplierSelector = new SupplierSelectorViewModel(
                 _supplierService,
                 _confirmationService,
                 _supplierDialogService);
-            SupplierSelector.InitializeAsync().GetAwaiter().GetResult();
             SupplierSelector.PropertyChanged += SupplierSelectorOnPropertyChanged;
 
             InputRow = new InvoiceItemInputViewModel(
@@ -102,14 +101,20 @@ namespace Facturon.App.ViewModels
                 _productDialogService,
                 _unitDialogService,
                 _taxDialogService);
-            InputRow.Initialize();
             InputRow.ItemReadyToAdd += InputRowOnItemReadyToAdd;
 
             DeleteSelectedItemCommand = new RelayCommand(DeleteSelectedItem, CanDeleteSelectedItem);
             BeginEditItemCommand = new RelayCommand(BeginEditItem, CanBeginEditItem);
+            LoadCommand = new RelayCommand(async () => await InitializeAsync());
 
             InvoiceItems = new ObservableCollection<InvoiceItemViewModel>();
             _mainViewModel.PropertyChanged += MainViewModel_PropertyChanged;
+        }
+
+        public async Task InitializeAsync()
+        {
+            await PaymentMethodSelector.InitializeAsync();
+            await SupplierSelector.InitializeAsync();
         }
 
         private Invoice? _invoice;

--- a/ViewModels/InvoiceItemInputViewModel.cs
+++ b/ViewModels/InvoiceItemInputViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Facturon.Domain.Entities;
 using Facturon.Services;
 
@@ -51,6 +52,7 @@ namespace Facturon.App.ViewModels
 
         public RelayCommand AddCommand { get; }
         public RelayCommand ClearCommand { get; }
+        public RelayCommand LoadCommand { get; }
 
         public event Action<InvoiceItem>? ItemReadyToAdd;
 
@@ -96,6 +98,7 @@ namespace Facturon.App.ViewModels
 
             AddCommand = new RelayCommand(Add, IsValid);
             ClearCommand = new RelayCommand(Clear);
+            LoadCommand = new RelayCommand(async () => await InitializeAsync());
         }
 
         private void ProductSelectorOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -112,11 +115,11 @@ namespace Facturon.App.ViewModels
                 AddCommand.RaiseCanExecuteChanged();
         }
 
-        public void Initialize()
+        public async Task InitializeAsync()
         {
-            ProductSelector.InitializeAsync().GetAwaiter().GetResult();
-            UnitSelector.InitializeAsync().GetAwaiter().GetResult();
-            TaxRateSelector.InitializeAsync(DateTime.Today).GetAwaiter().GetResult();
+            await ProductSelector.InitializeAsync();
+            await UnitSelector.InitializeAsync();
+            await TaxRateSelector.InitializeAsync(DateTime.Today);
         }
 
         private void Add()

--- a/ViewModels/NewProductDialogViewModel.cs
+++ b/ViewModels/NewProductDialogViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Facturon.Domain.Entities;
 using Facturon.Services;
 
@@ -49,6 +50,7 @@ namespace Facturon.App.ViewModels
 
         public RelayCommand SaveCommand { get; }
         public RelayCommand CancelCommand { get; }
+        public RelayCommand LoadCommand { get; }
 
         public event Action<Product?>? CloseRequested;
 
@@ -80,6 +82,7 @@ namespace Facturon.App.ViewModels
 
             SaveCommand = new RelayCommand(Save, CanSave);
             CancelCommand = new RelayCommand(() => CloseRequested?.Invoke(null));
+            LoadCommand = new RelayCommand(async () => await InitializeAsync());
         }
 
         private void UnitSelectorOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -114,11 +117,11 @@ namespace Facturon.App.ViewModels
             }
         }
 
-        public void Initialize()
+        public async Task InitializeAsync()
         {
-            UnitSelector.InitializeAsync().GetAwaiter().GetResult();
-            TaxRateSelector.InitializeAsync(DateTime.Today).GetAwaiter().GetResult();
-            ProductGroupSelector.InitializeAsync().GetAwaiter().GetResult();
+            await UnitSelector.InitializeAsync();
+            await TaxRateSelector.InitializeAsync(DateTime.Today);
+            await ProductGroupSelector.InitializeAsync();
         }
 
         private bool CanSave()

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -4,7 +4,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:views="clr-namespace:Facturon.App.Views"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d">
+    <i:Interaction.Triggers>
+        <EventTrigger EventName="Loaded">
+            <i:InvokeCommandAction Command="{Binding LoadCommand}" />
+        </EventTrigger>
+    </i:Interaction.Triggers>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/Views/InvoiceItemInputView.xaml
+++ b/Views/InvoiceItemInputView.xaml
@@ -1,7 +1,13 @@
 <UserControl x:Class="Facturon.App.Views.InvoiceItemInputView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:views="clr-namespace:Facturon.App.Views">
+             xmlns:views="clr-namespace:Facturon.App.Views"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors">
+    <i:Interaction.Triggers>
+        <EventTrigger EventName="Loaded">
+            <i:InvokeCommandAction Command="{Binding LoadCommand}" />
+        </EventTrigger>
+    </i:Interaction.Triggers>
     <UserControl.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding AddCommand}" />
         <KeyBinding Key="Escape" Command="{Binding ClearCommand}" />

--- a/Views/NewProductDialog.xaml
+++ b/Views/NewProductDialog.xaml
@@ -2,11 +2,17 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Facturon.App.Views"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         Title="New Product"
         WindowStartupLocation="CenterOwner"
         SizeToContent="WidthAndHeight"
         WindowStyle="ToolWindow"
         FocusManager.FocusedElement="{Binding ElementName=NameBox}">
+    <i:Interaction.Triggers>
+        <EventTrigger EventName="Loaded">
+            <i:InvokeCommandAction Command="{Binding LoadCommand}" />
+        </EventTrigger>
+    </i:Interaction.Triggers>
     <StackPanel Margin="10">
         <TextBlock Text="Name:"/>
         <TextBox x:Name="NameBox" Width="200" Text="{Binding Product.Name, UpdateSourceTrigger=PropertyChanged}" />


### PR DESCRIPTION
## Summary
- add async initialization flow for InvoiceItemInputViewModel, NewProductDialogViewModel and InvoiceDetailViewModel
- bind `LoadCommand` to view `Loaded` events
- drop blocking calls from view model constructors
- remove obsolete `Initialize` invocation in dialog service
- record update in `PROMPT_LOG.md`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882da33b988832293eae4b7d3a87a23