### PR TITLE
Add navigation helpers and keyboard commands

### DIFF
--- a/Services/INavigationService.cs
+++ b/Services/INavigationService.cs
@@ -3,5 +3,7 @@ namespace Facturon.Services
     public interface INavigationService
     {
         void MoveFocus(FocusNavigationDirection direction);
+        void MoveNext();
+        void MovePrevious();
     }
 }

--- a/Startup/NavigationService.cs
+++ b/Startup/NavigationService.cs
@@ -14,5 +14,15 @@ namespace Facturon.App
                         (System.Windows.Input.FocusNavigationDirection)direction));
             }
         }
+
+        public void MoveNext()
+        {
+            MoveFocus(FocusNavigationDirection.Next);
+        }
+
+        public void MovePrevious()
+        {
+            MoveFocus(FocusNavigationDirection.Previous);
+        }
     }
 }

--- a/Startup/NewProductDialogService.cs
+++ b/Startup/NewProductDialogService.cs
@@ -15,6 +15,7 @@ namespace Facturon.App
         private readonly INewEntityDialogService<Unit> _unitDialogService;
         private readonly INewEntityDialogService<TaxRate> _taxRateDialogService;
         private readonly INewEntityDialogService<ProductGroup> _productGroupDialogService;
+        private readonly INavigationService _navigationService;
 
         public NewProductDialogService(
             IUnitService unitService,
@@ -24,7 +25,8 @@ namespace Facturon.App
             IConfirmationDialogService confirmationService,
             INewEntityDialogService<Unit> unitDialogService,
             INewEntityDialogService<TaxRate> taxRateDialogService,
-            INewEntityDialogService<ProductGroup> productGroupDialogService)
+            INewEntityDialogService<ProductGroup> productGroupDialogService,
+            INavigationService navigationService)
         {
             _unitService = unitService;
             _taxRateService = taxRateService;
@@ -34,6 +36,7 @@ namespace Facturon.App
             _unitDialogService = unitDialogService;
             _taxRateDialogService = taxRateDialogService;
             _productGroupDialogService = productGroupDialogService;
+            _navigationService = navigationService;
         }
 
         public Product? ShowDialog()
@@ -47,7 +50,8 @@ namespace Facturon.App
                 _confirmationService,
                 _unitDialogService,
                 _taxRateDialogService,
-                _productGroupDialogService);
+                _productGroupDialogService,
+                _navigationService);
             dialog.DataContext = vm;
             vm.CloseRequested += p => dialog.DialogResult = p != null;
             var result = dialog.ShowDialog();

--- a/Startup/StartupOrchestrator.cs
+++ b/Startup/StartupOrchestrator.cs
@@ -89,6 +89,7 @@ namespace Facturon.App
                             sp.GetRequiredService<INewEntityDialogService<Unit>>(),
                             sp.GetRequiredService<INewEntityDialogService<TaxRate>>(),
                             sp.GetRequiredService<INewEntityDialogService<Supplier>>(),
+                            sp.GetRequiredService<INavigationService>(),
                             sp.GetRequiredService<MainViewModel>()));
                     services.AddTransient<MainViewModel>();
                 });

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -25,6 +25,7 @@ namespace Facturon.App.ViewModels
         private readonly ISupplierService _supplierService;
         private readonly INewEntityDialogService<Supplier> _supplierDialogService;
         private readonly IInvoiceItemService _invoiceItemService;
+        private readonly INavigationService _navigationService;
         private readonly MainViewModel _mainViewModel;
 
         public SupplierSelectorViewModel SupplierSelector { get; }
@@ -64,6 +65,7 @@ namespace Facturon.App.ViewModels
             INewEntityDialogService<Unit> unitDialogService,
             INewEntityDialogService<TaxRate> taxDialogService,
             INewEntityDialogService<Supplier> supplierDialogService,
+            INavigationService navigationService,
             MainViewModel mainViewModel)
         {
             _invoiceService = invoiceService;
@@ -78,6 +80,7 @@ namespace Facturon.App.ViewModels
             _unitDialogService = unitDialogService;
             _taxDialogService = taxDialogService;
             _supplierService = supplierService;
+            _navigationService = navigationService;
             _supplierDialogService = supplierDialogService;
             _mainViewModel = mainViewModel;
 
@@ -100,7 +103,8 @@ namespace Facturon.App.ViewModels
                 _confirmationService,
                 _productDialogService,
                 _unitDialogService,
-                _taxDialogService);
+                _taxDialogService,
+                _navigationService);
             InputRow.ItemReadyToAdd += InputRowOnItemReadyToAdd;
 
             DeleteSelectedItemCommand = new RelayCommand(DeleteSelectedItem, CanDeleteSelectedItem);

--- a/ViewModels/InvoiceItemInputViewModel.cs
+++ b/ViewModels/InvoiceItemInputViewModel.cs
@@ -15,6 +15,7 @@ namespace Facturon.App.ViewModels
         private readonly INewEntityDialogService<Product> _productDialogService;
         private readonly INewEntityDialogService<Unit> _unitDialogService;
         private readonly INewEntityDialogService<TaxRate> _taxDialogService;
+        private readonly INavigationService _navigationService;
 
         public ProductSelectorViewModel ProductSelector { get; }
         public UnitSelectorViewModel UnitSelector { get; }
@@ -53,6 +54,8 @@ namespace Facturon.App.ViewModels
         public RelayCommand AddCommand { get; }
         public RelayCommand ClearCommand { get; }
         public RelayCommand LoadCommand { get; }
+        public RelayCommand MoveNextCommand { get; }
+        public RelayCommand MovePreviousCommand { get; }
 
         public event Action<InvoiceItem>? ItemReadyToAdd;
 
@@ -79,7 +82,8 @@ namespace Facturon.App.ViewModels
             IConfirmationDialogService confirmationService,
             INewEntityDialogService<Product> productDialogService,
             INewEntityDialogService<Unit> unitDialogService,
-            INewEntityDialogService<TaxRate> taxDialogService)
+            INewEntityDialogService<TaxRate> taxDialogService,
+            INavigationService navigationService)
         {
             _productService = productService;
             _unitService = unitService;
@@ -88,6 +92,7 @@ namespace Facturon.App.ViewModels
             _productDialogService = productDialogService;
             _unitDialogService = unitDialogService;
             _taxDialogService = taxDialogService;
+            _navigationService = navigationService;
 
             ProductSelector = new ProductSelectorViewModel(_productService, _confirmationService, _productDialogService);
             ProductSelector.PropertyChanged += ProductSelectorOnPropertyChanged;
@@ -99,6 +104,8 @@ namespace Facturon.App.ViewModels
             AddCommand = new RelayCommand(Add, IsValid);
             ClearCommand = new RelayCommand(Clear);
             LoadCommand = new RelayCommand(async () => await InitializeAsync());
+            MoveNextCommand = new RelayCommand(() => _navigationService.MoveNext());
+            MovePreviousCommand = new RelayCommand(() => _navigationService.MovePrevious());
         }
 
         private void ProductSelectorOnPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -124,6 +124,7 @@ namespace Facturon.App.ViewModels
                 _unitDialogService,
                 _taxDialogService,
                 _supplierDialogService,
+                _navigationService,
                 this);
 
             OpenInvoiceCommand = new RelayCommand(OpenSelected, () => ScreenState == InvoiceScreenState.Browsing && CanOpenSelected());

--- a/ViewModels/NewProductDialogViewModel.cs
+++ b/ViewModels/NewProductDialogViewModel.cs
@@ -17,6 +17,7 @@ namespace Facturon.App.ViewModels
         private readonly INewEntityDialogService<Unit> _unitDialogService;
         private readonly INewEntityDialogService<TaxRate> _taxRateDialogService;
         private readonly INewEntityDialogService<ProductGroup> _productGroupDialogService;
+        private readonly INavigationService _navigationService;
 
         public EditableComboWithAddViewModel<Unit> UnitSelector { get; }
         public TaxRateSelectorViewModel TaxRateSelector { get; }
@@ -51,6 +52,8 @@ namespace Facturon.App.ViewModels
         public RelayCommand SaveCommand { get; }
         public RelayCommand CancelCommand { get; }
         public RelayCommand LoadCommand { get; }
+        public RelayCommand MoveNextCommand { get; }
+        public RelayCommand MovePreviousCommand { get; }
 
         public event Action<Product?>? CloseRequested;
 
@@ -62,7 +65,8 @@ namespace Facturon.App.ViewModels
             IConfirmationDialogService confirmationService,
             INewEntityDialogService<Unit> unitDialogService,
             INewEntityDialogService<TaxRate> taxRateDialogService,
-            INewEntityDialogService<ProductGroup> productGroupDialogService)
+            INewEntityDialogService<ProductGroup> productGroupDialogService,
+            INavigationService navigationService)
         {
             _unitService = unitService;
             _taxRateService = taxRateService;
@@ -72,6 +76,7 @@ namespace Facturon.App.ViewModels
             _unitDialogService = unitDialogService;
             _taxRateDialogService = taxRateDialogService;
             _productGroupDialogService = productGroupDialogService;
+            _navigationService = navigationService;
 
             UnitSelector = new EditableComboWithAddViewModel<Unit>(_unitService, _confirmationService, _unitDialogService);
             UnitSelector.PropertyChanged += UnitSelectorOnPropertyChanged;
@@ -83,6 +88,8 @@ namespace Facturon.App.ViewModels
             SaveCommand = new RelayCommand(Save, CanSave);
             CancelCommand = new RelayCommand(() => CloseRequested?.Invoke(null));
             LoadCommand = new RelayCommand(async () => await InitializeAsync());
+            MoveNextCommand = new RelayCommand(() => _navigationService.MoveNext());
+            MovePreviousCommand = new RelayCommand(() => _navigationService.MovePrevious());
         }
 
         private void UnitSelectorOnPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/Views/InvoiceItemInputView.xaml
+++ b/Views/InvoiceItemInputView.xaml
@@ -9,7 +9,8 @@
         </EventTrigger>
     </i:Interaction.Triggers>
     <UserControl.InputBindings>
-        <KeyBinding Key="Enter" Command="{Binding AddCommand}" />
+        <KeyBinding Key="Enter" Command="{Binding MoveNextCommand}" />
+        <KeyBinding Modifiers="Shift" Key="Enter" Command="{Binding MovePreviousCommand}" />
         <KeyBinding Key="Escape" Command="{Binding ClearCommand}" />
     </UserControl.InputBindings>
     <StackPanel Orientation="Horizontal">

--- a/Views/NewProductDialog.xaml
+++ b/Views/NewProductDialog.xaml
@@ -8,6 +8,10 @@
         SizeToContent="WidthAndHeight"
         WindowStyle="ToolWindow"
         FocusManager.FocusedElement="{Binding ElementName=NameBox}">
+    <Window.InputBindings>
+        <KeyBinding Key="Enter" Command="{Binding MoveNextCommand}" />
+        <KeyBinding Modifiers="Shift" Key="Enter" Command="{Binding MovePreviousCommand}" />
+    </Window.InputBindings>
     <i:Interaction.Triggers>
         <EventTrigger EventName="Loaded">
             <i:InvokeCommandAction Command="{Binding LoadCommand}" />


### PR DESCRIPTION
## Summary
- extend `INavigationService` with MoveNext/MovePrevious
- implement helpers in `NavigationService`
- wire navigation service into item and dialog view models
- bind Enter/Shift+Enter to MoveNext/MovePrevious

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6882e6b51c788322a1ffecb1efe44358