### PR TITLE
Restore focus after adding invoice item

### DIFF
--- a/Tests/ViewModels/InvoiceItemInputViewModelTests.cs
+++ b/Tests/ViewModels/InvoiceItemInputViewModelTests.cs
@@ -1,0 +1,51 @@
+using Facturon.App.ViewModels;
+using Facturon.Domain.Entities;
+using Facturon.Services;
+using Moq;
+using Xunit;
+
+namespace Facturon.Tests.ViewModels
+{
+    public class InvoiceItemInputViewModelTests
+    {
+        private static InvoiceItemInputViewModel CreateVm()
+        {
+            var productService = new Mock<IProductService>();
+            var unitService = new Mock<IUnitService>();
+            var taxRateService = new Mock<ITaxRateService>();
+            var confirmation = new Mock<IConfirmationDialogService>();
+            var productDialog = new Mock<INewEntityDialogService<Product>>();
+            var unitDialog = new Mock<INewEntityDialogService<Unit>>();
+            var taxDialog = new Mock<INewEntityDialogService<TaxRate>>();
+            var nav = new Mock<INavigationService>();
+            return new InvoiceItemInputViewModel(
+                productService.Object,
+                unitService.Object,
+                taxRateService.Object,
+                confirmation.Object,
+                productDialog.Object,
+                unitDialog.Object,
+                taxDialog.Object,
+                nav.Object);
+        }
+
+        [Fact]
+        public void Add_RaisesFocusRequested()
+        {
+            var vm = CreateVm();
+            vm.ProductSelector.SelectedItem = new Product { Id = 1 };
+            vm.UnitSelector.SelectedItem = new Unit { Id = 1 };
+            vm.TaxRateSelector.SelectedItem = new TaxRate { Id = 1, Value = 20m };
+            vm.Quantity = 1;
+            vm.NetUnitPrice = 10m;
+
+            var raised = false;
+            vm.FocusRequested += () => raised = true;
+            vm.AddCommand.Execute(null);
+
+            Assert.True(raised);
+            Assert.Equal(1m, vm.Quantity);
+            Assert.Equal(0m, vm.NetUnitPrice);
+        }
+    }
+}

--- a/ViewModels/InvoiceItemInputViewModel.cs
+++ b/ViewModels/InvoiceItemInputViewModel.cs
@@ -58,6 +58,7 @@ namespace Facturon.App.ViewModels
         public RelayCommand MovePreviousCommand { get; }
 
         public event Action<InvoiceItem>? ItemReadyToAdd;
+        public event Action? FocusRequested;
 
         public InvoiceItemViewModel? EditingItem { get; private set; }
         private bool _isEditing;
@@ -156,6 +157,7 @@ namespace Facturon.App.ViewModels
 
             ItemReadyToAdd?.Invoke(item);
             Clear();
+            FocusRequested?.Invoke();
         }
 
         private void Clear()
@@ -230,6 +232,7 @@ namespace Facturon.App.ViewModels
             EditingItem = null;
             IsEditing = false;
             Clear();
+            FocusRequested?.Invoke();
         }
     }
 }

--- a/Views/EditableComboWithAdd.xaml.cs
+++ b/Views/EditableComboWithAdd.xaml.cs
@@ -18,5 +18,10 @@ namespace Facturon.App.Views
         {
             InitializeComponent();
         }
+
+        public void FocusInput()
+        {
+            Combo.Focus();
+        }
     }
 }

--- a/Views/InvoiceItemInputView.xaml
+++ b/Views/InvoiceItemInputView.xaml
@@ -7,6 +7,9 @@
         <EventTrigger EventName="Loaded">
             <i:InvokeCommandAction Command="{Binding LoadCommand}" />
         </EventTrigger>
+        <i:EventTrigger SourceObject="{Binding}" EventName="FocusRequested">
+            <i:CallMethodAction TargetObject="{Binding ElementName=ProductCombo}" MethodName="FocusInput" />
+        </i:EventTrigger>
     </i:Interaction.Triggers>
     <UserControl.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding MoveNextCommand}" />
@@ -14,7 +17,8 @@
         <KeyBinding Key="Escape" Command="{Binding ClearCommand}" />
     </UserControl.InputBindings>
     <StackPanel Orientation="Horizontal">
-        <views:EditableComboWithAdd Width="200"
+        <views:EditableComboWithAdd x:Name="ProductCombo"
+                                    Width="200"
                                     DataContext="{Binding ProductSelector}"
                                     DisplayMemberPath="Name" />
         <TextBox Width="60"


### PR DESCRIPTION
## Summary
- raise `FocusRequested` in `InvoiceItemInputViewModel`
- expose `FocusInput` method on `EditableComboWithAdd`
- handle `FocusRequested` from `InvoiceItemInputView` to refocus the product combo
- add unit test for focus event

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882ec08f3bc832285ab80abecdbec02