### PR TITLE
Load recent selections in combo boxes

### DIFF
--- a/Services/IEntityService.cs
+++ b/Services/IEntityService.cs
@@ -1,11 +1,13 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Facturon.Domain.Entities;
 
 namespace Facturon.Services
 {
-    public interface IEntityService<TEntity>
+    public interface IEntityService<TEntity> where TEntity : BaseEntity
     {
         Task<List<TEntity>> GetAllAsync();
+        Task<List<TEntity>> GetMostRecentAsync(int count);
         Task<Result> CreateAsync(TEntity entity);
     }
 }

--- a/Services/ISelectionHistoryService.cs
+++ b/Services/ISelectionHistoryService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Facturon.Services
+{
+    public interface ISelectionHistoryService
+    {
+        Task RecordSelectionAsync(string entityName, int id);
+        Task<List<int>> GetRecentIdsAsync(string entityName, int count);
+    }
+}

--- a/Services/ProductGroupService.cs
+++ b/Services/ProductGroupService.cs
@@ -10,11 +10,13 @@ namespace Facturon.Services
     {
         private readonly IProductGroupRepository _groupRepository;
         private readonly IProductRepository _productRepository;
+        private readonly ISelectionHistoryService _historyService;
 
-        public ProductGroupService(IProductGroupRepository groupRepository, IProductRepository productRepository)
+        public ProductGroupService(IProductGroupRepository groupRepository, IProductRepository productRepository, ISelectionHistoryService historyService)
         {
             _groupRepository = groupRepository;
             _productRepository = productRepository;
+            _historyService = historyService;
         }
 
         public async Task<ProductGroup?> GetByIdAsync(int id)
@@ -25,6 +27,19 @@ namespace Facturon.Services
         public async Task<List<ProductGroup>> GetAllAsync()
         {
             return await _groupRepository.GetAllAsync();
+        }
+
+        public async Task<List<ProductGroup>> GetMostRecentAsync(int count)
+        {
+            var ids = await _historyService.GetRecentIdsAsync(nameof(ProductGroup), count);
+            var list = new List<ProductGroup>();
+            foreach (var id in ids)
+            {
+                var item = await _groupRepository.GetByIdAsync(id);
+                if (item != null && item.Active)
+                    list.Add(item);
+            }
+            return list;
         }
 
         public async Task<Result> CreateAsync(ProductGroup group)

--- a/Services/ProductService.cs
+++ b/Services/ProductService.cs
@@ -14,19 +14,22 @@ namespace Facturon.Services
         private readonly IProductGroupRepository _productGroupRepository;
         private readonly ITaxRateRepository _taxRateRepository;
         private readonly IInvoiceRepository _invoiceRepository;
+        private readonly ISelectionHistoryService _historyService;
 
         public ProductService(
             IProductRepository productRepository,
             IUnitRepository unitRepository,
             IProductGroupRepository productGroupRepository,
             ITaxRateRepository taxRateRepository,
-            IInvoiceRepository invoiceRepository)
+            IInvoiceRepository invoiceRepository,
+            ISelectionHistoryService historyService)
         {
             _productRepository = productRepository;
             _unitRepository = unitRepository;
             _productGroupRepository = productGroupRepository;
             _taxRateRepository = taxRateRepository;
             _invoiceRepository = invoiceRepository;
+            _historyService = historyService;
         }
 
         public async Task<Product?> GetByIdAsync(int id)
@@ -37,6 +40,19 @@ namespace Facturon.Services
         public async Task<List<Product>> GetAllAsync()
         {
             return await _productRepository.GetAllAsync();
+        }
+
+        public async Task<List<Product>> GetMostRecentAsync(int count)
+        {
+            var ids = await _historyService.GetRecentIdsAsync(nameof(Product), count);
+            var list = new List<Product>();
+            foreach (var id in ids)
+            {
+                var item = await _productRepository.GetByIdAsync(id);
+                if (item != null && item.Active)
+                    list.Add(item);
+            }
+            return list;
         }
 
         public async Task<Result> CreateAsync(Product product)

--- a/Services/SelectionHistoryService.cs
+++ b/Services/SelectionHistoryService.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturon.Services
+{
+    public class SelectionHistoryService : ISelectionHistoryService
+    {
+        private readonly string _filePath;
+        private readonly SemaphoreSlim _lock = new(1, 1);
+
+        private record Entry(int Id, DateTime Date);
+
+        public SelectionHistoryService()
+        {
+            var baseDir = AppContext.BaseDirectory;
+            _filePath = Path.Combine(baseDir, "selectionhistory.json");
+        }
+
+        private async Task<Dictionary<string, List<Entry>>> LoadAsync()
+        {
+            if (!File.Exists(_filePath))
+                return new();
+            var json = await File.ReadAllTextAsync(_filePath);
+            return JsonSerializer.Deserialize<Dictionary<string, List<Entry>>>(json) ?? new();
+        }
+
+        private async Task SaveAsync(Dictionary<string, List<Entry>> data)
+        {
+            var json = JsonSerializer.Serialize(data);
+            await File.WriteAllTextAsync(_filePath, json);
+        }
+
+        public async Task RecordSelectionAsync(string entityName, int id)
+        {
+            await _lock.WaitAsync();
+            try
+            {
+                var data = await LoadAsync();
+                if (!data.TryGetValue(entityName, out var list))
+                {
+                    list = new List<Entry>();
+                    data[entityName] = list;
+                }
+
+                var existing = list.FirstOrDefault(e => e.Id == id);
+                if (existing != null)
+                {
+                    list.Remove(existing);
+                }
+                list.Insert(0, new Entry(id, DateTime.UtcNow));
+                await SaveAsync(data);
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+        public async Task<List<int>> GetRecentIdsAsync(string entityName, int count)
+        {
+            await _lock.WaitAsync();
+            try
+            {
+                var data = await LoadAsync();
+                if (data.TryGetValue(entityName, out var list))
+                {
+                    return list.OrderByDescending(e => e.Date).Take(count).Select(e => e.Id).ToList();
+                }
+                return new();
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+    }
+}

--- a/Services/SupplierService.cs
+++ b/Services/SupplierService.cs
@@ -10,11 +10,13 @@ namespace Facturon.Services
     {
         private readonly ISupplierRepository _supplierRepository;
         private readonly IInvoiceRepository _invoiceRepository;
+        private readonly ISelectionHistoryService _historyService;
 
-        public SupplierService(ISupplierRepository supplierRepository, IInvoiceRepository invoiceRepository)
+        public SupplierService(ISupplierRepository supplierRepository, IInvoiceRepository invoiceRepository, ISelectionHistoryService historyService)
         {
             _supplierRepository = supplierRepository;
             _invoiceRepository = invoiceRepository;
+            _historyService = historyService;
         }
 
         public async Task<Supplier?> GetByIdAsync(int id)
@@ -25,6 +27,19 @@ namespace Facturon.Services
         public async Task<List<Supplier>> GetAllAsync()
         {
             return await _supplierRepository.GetAllAsync();
+        }
+
+        public async Task<List<Supplier>> GetMostRecentAsync(int count)
+        {
+            var ids = await _historyService.GetRecentIdsAsync(nameof(Supplier), count);
+            var list = new List<Supplier>();
+            foreach (var id in ids)
+            {
+                var item = await _supplierRepository.GetByIdAsync(id);
+                if (item != null && item.Active)
+                    list.Add(item);
+            }
+            return list;
         }
 
         public async Task<Result> CreateAsync(Supplier supplier)

--- a/Services/TaxRateService.cs
+++ b/Services/TaxRateService.cs
@@ -10,11 +10,13 @@ namespace Facturon.Services
     {
         private readonly ITaxRateRepository _taxRateRepository;
         private readonly IProductRepository _productRepository;
+        private readonly ISelectionHistoryService _historyService;
 
-        public TaxRateService(ITaxRateRepository taxRateRepository, IProductRepository productRepository)
+        public TaxRateService(ITaxRateRepository taxRateRepository, IProductRepository productRepository, ISelectionHistoryService historyService)
         {
             _taxRateRepository = taxRateRepository;
             _productRepository = productRepository;
+            _historyService = historyService;
         }
 
         public async Task<TaxRate?> GetByIdAsync(int id)
@@ -25,6 +27,19 @@ namespace Facturon.Services
         public async Task<List<TaxRate>> GetAllAsync()
         {
             return await _taxRateRepository.GetAllAsync();
+        }
+
+        public async Task<List<TaxRate>> GetMostRecentAsync(int count)
+        {
+            var ids = await _historyService.GetRecentIdsAsync(nameof(TaxRate), count);
+            var list = new List<TaxRate>();
+            foreach (var id in ids)
+            {
+                var item = await _taxRateRepository.GetByIdAsync(id);
+                if (item != null && item.Active)
+                    list.Add(item);
+            }
+            return list;
         }
 
         public async Task<List<TaxRate>> GetActiveForDateAsync(DateTime date)

--- a/Services/UnitService.cs
+++ b/Services/UnitService.cs
@@ -10,11 +10,13 @@ namespace Facturon.Services
     {
         private readonly IUnitRepository _unitRepository;
         private readonly IProductRepository _productRepository;
+        private readonly ISelectionHistoryService _historyService;
 
-        public UnitService(IUnitRepository unitRepository, IProductRepository productRepository)
+        public UnitService(IUnitRepository unitRepository, IProductRepository productRepository, ISelectionHistoryService historyService)
         {
             _unitRepository = unitRepository;
             _productRepository = productRepository;
+            _historyService = historyService;
         }
 
         public async Task<Unit?> GetByIdAsync(int id)
@@ -25,6 +27,19 @@ namespace Facturon.Services
         public async Task<List<Unit>> GetAllAsync()
         {
             return await _unitRepository.GetAllAsync();
+        }
+
+        public async Task<List<Unit>> GetMostRecentAsync(int count)
+        {
+            var ids = await _historyService.GetRecentIdsAsync(nameof(Unit), count);
+            var list = new List<Unit>();
+            foreach (var id in ids)
+            {
+                var item = await _unitRepository.GetByIdAsync(id);
+                if (item != null && item.Active)
+                    list.Add(item);
+            }
+            return list;
         }
 
         public async Task<Result> CreateAsync(Unit unit)

--- a/Startup/NewProductDialogService.cs
+++ b/Startup/NewProductDialogService.cs
@@ -16,6 +16,7 @@ namespace Facturon.App
         private readonly INewEntityDialogService<TaxRate> _taxRateDialogService;
         private readonly INewEntityDialogService<ProductGroup> _productGroupDialogService;
         private readonly INavigationService _navigationService;
+        private readonly ISelectionHistoryService _historyService;
 
         public NewProductDialogService(
             IUnitService unitService,
@@ -26,7 +27,8 @@ namespace Facturon.App
             INewEntityDialogService<Unit> unitDialogService,
             INewEntityDialogService<TaxRate> taxRateDialogService,
             INewEntityDialogService<ProductGroup> productGroupDialogService,
-            INavigationService navigationService)
+            INavigationService navigationService,
+            ISelectionHistoryService historyService)
         {
             _unitService = unitService;
             _taxRateService = taxRateService;
@@ -37,6 +39,7 @@ namespace Facturon.App
             _taxRateDialogService = taxRateDialogService;
             _productGroupDialogService = productGroupDialogService;
             _navigationService = navigationService;
+            _historyService = historyService;
         }
 
         public Product? ShowDialog()
@@ -51,7 +54,8 @@ namespace Facturon.App
                 _unitDialogService,
                 _taxRateDialogService,
                 _productGroupDialogService,
-                _navigationService);
+                _navigationService,
+                _historyService);
             dialog.DataContext = vm;
             vm.CloseRequested += p => dialog.DialogResult = p != null;
             var result = dialog.ShowDialog();

--- a/Startup/StartupOrchestrator.cs
+++ b/Startup/StartupOrchestrator.cs
@@ -71,6 +71,7 @@ namespace Facturon.App
                     services.AddSingleton<INewEntityDialogService<PaymentMethod>, NewPaymentMethodDialogService>();
 
                     services.AddSingleton<INavigationService, NavigationService>();
+                    services.AddSingleton<ISelectionHistoryService, SelectionHistoryService>();
 
                     services.AddSingleton<MainWindow>();
                     services.AddTransient<InvoiceListViewModel>();
@@ -90,7 +91,8 @@ namespace Facturon.App
                             sp.GetRequiredService<INewEntityDialogService<TaxRate>>(),
                             sp.GetRequiredService<INewEntityDialogService<Supplier>>(),
                             sp.GetRequiredService<INavigationService>(),
-                            sp.GetRequiredService<MainViewModel>()));
+                            sp.GetRequiredService<MainViewModel>(),
+                            sp.GetRequiredService<ISelectionHistoryService>()));
                     services.AddTransient<MainViewModel>();
                 });
 

--- a/Tests/ViewModels/InvoiceItemInputViewModelTests.cs
+++ b/Tests/ViewModels/InvoiceItemInputViewModelTests.cs
@@ -18,6 +18,7 @@ namespace Facturon.Tests.ViewModels
             var unitDialog = new Mock<INewEntityDialogService<Unit>>();
             var taxDialog = new Mock<INewEntityDialogService<TaxRate>>();
             var nav = new Mock<INavigationService>();
+            var history = new Mock<ISelectionHistoryService>();
             return new InvoiceItemInputViewModel(
                 productService.Object,
                 unitService.Object,
@@ -26,7 +27,8 @@ namespace Facturon.Tests.ViewModels
                 productDialog.Object,
                 unitDialog.Object,
                 taxDialog.Object,
-                nav.Object);
+                nav.Object,
+                history.Object);
         }
 
         [Fact]

--- a/Tests/ViewModels/SupplierSelectorViewModelTests.cs
+++ b/Tests/ViewModels/SupplierSelectorViewModelTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Facturon.App.ViewModels;
+using Facturon.Domain.Entities;
+using Facturon.Services;
+using Moq;
+using Xunit;
+
+namespace Facturon.Tests.ViewModels
+{
+    public class SupplierSelectorViewModelTests
+    {
+        [Fact]
+        public async Task InitializeAsync_LoadsRecentFirst()
+        {
+            var service = new Mock<ISupplierService>();
+            var confirm = new Mock<IConfirmationDialogService>();
+            var dialog = new Mock<INewEntityDialogService<Supplier>>();
+            var history = new Mock<ISelectionHistoryService>();
+
+            var recent = new Supplier { Id = 2, Name = "B" };
+            var all = new List<Supplier>
+            {
+                new Supplier { Id = 1, Name = "A" },
+                recent
+            };
+
+            service.Setup(s => s.GetMostRecentAsync(It.IsAny<int>())).ReturnsAsync(new List<Supplier> { recent });
+            service.Setup(s => s.GetAllAsync()).ReturnsAsync(all);
+
+            var vm = new SupplierSelectorViewModel(service.Object, confirm.Object, dialog.Object, history.Object);
+            await vm.InitializeAsync();
+
+            Assert.Equal(recent, vm.Items[0]);
+        }
+    }
+}

--- a/ViewModels/InvoiceDetailViewModel.cs
+++ b/ViewModels/InvoiceDetailViewModel.cs
@@ -27,6 +27,7 @@ namespace Facturon.App.ViewModels
         private readonly IInvoiceItemService _invoiceItemService;
         private readonly INavigationService _navigationService;
         private readonly MainViewModel _mainViewModel;
+        private readonly ISelectionHistoryService _historyService;
 
         public SupplierSelectorViewModel SupplierSelector { get; }
         public PaymentMethodSelectorViewModel PaymentMethodSelector { get; }
@@ -66,7 +67,8 @@ namespace Facturon.App.ViewModels
             INewEntityDialogService<TaxRate> taxDialogService,
             INewEntityDialogService<Supplier> supplierDialogService,
             INavigationService navigationService,
-            MainViewModel mainViewModel)
+            MainViewModel mainViewModel,
+            ISelectionHistoryService historyService)
         {
             _invoiceService = invoiceService;
             _paymentMethodService = paymentMethodService;
@@ -83,17 +85,20 @@ namespace Facturon.App.ViewModels
             _navigationService = navigationService;
             _supplierDialogService = supplierDialogService;
             _mainViewModel = mainViewModel;
+            _historyService = historyService;
 
             PaymentMethodSelector = new PaymentMethodSelectorViewModel(
                 _paymentMethodService,
                 _confirmationService,
-                _paymentMethodDialogService);
+                _paymentMethodDialogService,
+                historyService);
             PaymentMethodSelector.PropertyChanged += PaymentMethodSelectorOnPropertyChanged;
 
             SupplierSelector = new SupplierSelectorViewModel(
                 _supplierService,
                 _confirmationService,
-                _supplierDialogService);
+                _supplierDialogService,
+                historyService);
             SupplierSelector.PropertyChanged += SupplierSelectorOnPropertyChanged;
 
             InputRow = new InvoiceItemInputViewModel(
@@ -104,7 +109,8 @@ namespace Facturon.App.ViewModels
                 _productDialogService,
                 _unitDialogService,
                 _taxDialogService,
-                _navigationService);
+                _navigationService,
+                historyService);
             InputRow.ItemReadyToAdd += InputRowOnItemReadyToAdd;
 
             DeleteSelectedItemCommand = new RelayCommand(DeleteSelectedItem, CanDeleteSelectedItem);

--- a/ViewModels/InvoiceItemInputViewModel.cs
+++ b/ViewModels/InvoiceItemInputViewModel.cs
@@ -16,6 +16,7 @@ namespace Facturon.App.ViewModels
         private readonly INewEntityDialogService<Unit> _unitDialogService;
         private readonly INewEntityDialogService<TaxRate> _taxDialogService;
         private readonly INavigationService _navigationService;
+        private readonly ISelectionHistoryService _historyService;
 
         public ProductSelectorViewModel ProductSelector { get; }
         public UnitSelectorViewModel UnitSelector { get; }
@@ -84,7 +85,8 @@ namespace Facturon.App.ViewModels
             INewEntityDialogService<Product> productDialogService,
             INewEntityDialogService<Unit> unitDialogService,
             INewEntityDialogService<TaxRate> taxDialogService,
-            INavigationService navigationService)
+            INavigationService navigationService,
+            ISelectionHistoryService historyService)
         {
             _productService = productService;
             _unitService = unitService;
@@ -94,12 +96,13 @@ namespace Facturon.App.ViewModels
             _unitDialogService = unitDialogService;
             _taxDialogService = taxDialogService;
             _navigationService = navigationService;
+            _historyService = historyService;
 
-            ProductSelector = new ProductSelectorViewModel(_productService, _confirmationService, _productDialogService);
+            ProductSelector = new ProductSelectorViewModel(_productService, _confirmationService, _productDialogService, historyService);
             ProductSelector.PropertyChanged += ProductSelectorOnPropertyChanged;
-            UnitSelector = new UnitSelectorViewModel(_unitService, _confirmationService, _unitDialogService);
+            UnitSelector = new UnitSelectorViewModel(_unitService, _confirmationService, _unitDialogService, historyService);
             UnitSelector.PropertyChanged += SelectorOnPropertyChanged;
-            TaxRateSelector = new TaxRateSelectorViewModel(_taxRateService, _confirmationService, _taxDialogService);
+            TaxRateSelector = new TaxRateSelectorViewModel(_taxRateService, _confirmationService, _taxDialogService, historyService);
             TaxRateSelector.PropertyChanged += SelectorOnPropertyChanged;
 
             AddCommand = new RelayCommand(Add, IsValid);

--- a/ViewModels/NewProductDialogViewModel.cs
+++ b/ViewModels/NewProductDialogViewModel.cs
@@ -66,7 +66,8 @@ namespace Facturon.App.ViewModels
             INewEntityDialogService<Unit> unitDialogService,
             INewEntityDialogService<TaxRate> taxRateDialogService,
             INewEntityDialogService<ProductGroup> productGroupDialogService,
-            INavigationService navigationService)
+            INavigationService navigationService,
+            ISelectionHistoryService historyService)
         {
             _unitService = unitService;
             _taxRateService = taxRateService;
@@ -78,11 +79,11 @@ namespace Facturon.App.ViewModels
             _productGroupDialogService = productGroupDialogService;
             _navigationService = navigationService;
 
-            UnitSelector = new EditableComboWithAddViewModel<Unit>(_unitService, _confirmationService, _unitDialogService);
+            UnitSelector = new EditableComboWithAddViewModel<Unit>(_unitService, _confirmationService, _unitDialogService, historyService);
             UnitSelector.PropertyChanged += UnitSelectorOnPropertyChanged;
-            TaxRateSelector = new TaxRateSelectorViewModel(_taxRateService, _confirmationService, _taxRateDialogService);
+            TaxRateSelector = new TaxRateSelectorViewModel(_taxRateService, _confirmationService, _taxRateDialogService, historyService);
             TaxRateSelector.PropertyChanged += TaxRateSelectorOnPropertyChanged;
-            ProductGroupSelector = new ProductGroupSelectorViewModel(_productGroupService, _confirmationService, _productGroupDialogService);
+            ProductGroupSelector = new ProductGroupSelectorViewModel(_productGroupService, _confirmationService, _productGroupDialogService, historyService);
             ProductGroupSelector.PropertyChanged += ProductGroupSelectorOnPropertyChanged;
 
             SaveCommand = new RelayCommand(Save, CanSave);

--- a/ViewModels/PaymentMethodSelectorViewModel.cs
+++ b/ViewModels/PaymentMethodSelectorViewModel.cs
@@ -8,8 +8,9 @@ namespace Facturon.App.ViewModels
         public PaymentMethodSelectorViewModel(
             IPaymentMethodService service,
             IConfirmationDialogService confirmationService,
-            INewEntityDialogService<PaymentMethod> dialogService)
-            : base(service, confirmationService, dialogService)
+            INewEntityDialogService<PaymentMethod> dialogService,
+            ISelectionHistoryService historyService)
+            : base(service, confirmationService, dialogService, historyService)
         {
         }
     }

--- a/ViewModels/ProductGroupSelectorViewModel.cs
+++ b/ViewModels/ProductGroupSelectorViewModel.cs
@@ -8,8 +8,9 @@ namespace Facturon.App.ViewModels
         public ProductGroupSelectorViewModel(
             IProductGroupService service,
             IConfirmationDialogService confirmationService,
-            INewEntityDialogService<ProductGroup> dialogService)
-            : base(service, confirmationService, dialogService)
+            INewEntityDialogService<ProductGroup> dialogService,
+            ISelectionHistoryService historyService)
+            : base(service, confirmationService, dialogService, historyService)
         {
         }
     }

--- a/ViewModels/ProductSelectorViewModel.cs
+++ b/ViewModels/ProductSelectorViewModel.cs
@@ -8,8 +8,9 @@ namespace Facturon.App.ViewModels
         public ProductSelectorViewModel(
             IProductService service,
             IConfirmationDialogService confirmationService,
-            INewEntityDialogService<Product> dialogService)
-            : base(service, confirmationService, dialogService)
+            INewEntityDialogService<Product> dialogService,
+            ISelectionHistoryService historyService)
+            : base(service, confirmationService, dialogService, historyService)
         {
         }
     }

--- a/ViewModels/SupplierSelectorViewModel.cs
+++ b/ViewModels/SupplierSelectorViewModel.cs
@@ -8,8 +8,9 @@ namespace Facturon.App.ViewModels
         public SupplierSelectorViewModel(
             ISupplierService service,
             IConfirmationDialogService confirmationService,
-            INewEntityDialogService<Supplier> dialogService)
-            : base(service, confirmationService, dialogService)
+            INewEntityDialogService<Supplier> dialogService,
+            ISelectionHistoryService historyService)
+            : base(service, confirmationService, dialogService, historyService)
         {
         }
     }

--- a/ViewModels/TaxRateSelectorViewModel.cs
+++ b/ViewModels/TaxRateSelectorViewModel.cs
@@ -12,17 +12,21 @@ namespace Facturon.App.ViewModels
         public TaxRateSelectorViewModel(
             ITaxRateService service,
             IConfirmationDialogService confirmationService,
-            INewEntityDialogService<TaxRate> dialogService)
-            : base(service, confirmationService, dialogService)
+            INewEntityDialogService<TaxRate> dialogService,
+            ISelectionHistoryService historyService)
+            : base(service, confirmationService, dialogService, historyService)
         {
             _taxRateService = service;
         }
 
         public async Task InitializeAsync(DateTime date)
         {
-            var items = await _taxRateService.GetActiveForDateAsync(date);
             Items.Clear();
-            foreach (var item in items)
+            var recent = await _taxRateService.GetMostRecentAsync(5);
+            foreach (var item in recent.Where(r => r.ValidFrom <= date && r.ValidTo >= date))
+                Items.Add(item);
+            var items = await _taxRateService.GetActiveForDateAsync(date);
+            foreach (var item in items.Where(i => Items.All(r => r.Id != i.Id)))
                 Items.Add(item);
         }
     }

--- a/ViewModels/UnitSelectorViewModel.cs
+++ b/ViewModels/UnitSelectorViewModel.cs
@@ -8,8 +8,9 @@ namespace Facturon.App.ViewModels
         public UnitSelectorViewModel(
             IUnitService service,
             IConfirmationDialogService confirmationService,
-            INewEntityDialogService<Unit> dialogService)
-            : base(service, confirmationService, dialogService)
+            INewEntityDialogService<Unit> dialogService,
+            ISelectionHistoryService historyService)
+            : base(service, confirmationService, dialogService, historyService)
         {
         }
     }


### PR DESCRIPTION
## Summary
- allow `IEntityService` to return most recent items
- keep selection history in a JSON file via `SelectionHistoryService`
- inject history service into selector view models and services
- load recent entities first in editable combo lists
- test that recent suppliers appear first

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882f1de5d0483228e09148122f6ead5