### PR TITLE
Implement IDataErrorInfo validation for dialogs

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -311,3 +311,10 @@ Initialized _invoiceItems collection at declaration in InvoiceDetailViewModel to
 - Added FilteredItems ICollectionView in EditableComboWithAddViewModel to filter Items as Input changes.
 - Updated EditableComboWithAdd view to bind ComboBox.ItemsSource to FilteredItems.
 
+## [ui_agent] Add IDataErrorInfo to unit and supplier dialogs
+Implemented property-level validation in NewSupplierDialogViewModel and
+NewUnitDialogViewModel with duplicate checks. Updated associated XAML to
+use validation templates from LightTheme.
+## [test_agent] Validate dialog view model errors
+Added unit tests covering required and duplicate name rules for the new
+IDataErrorInfo implementations.

--- a/Startup/NewSupplierDialogService.cs
+++ b/Startup/NewSupplierDialogService.cs
@@ -7,10 +7,17 @@ namespace Facturon.App
 {
     public class NewSupplierDialogService : INewEntityDialogService<Supplier>
     {
+        private readonly ISupplierService _service;
+
+        public NewSupplierDialogService(ISupplierService service)
+        {
+            _service = service;
+        }
+
         public Supplier? ShowDialog()
         {
             var dialog = new NewSupplierDialog();
-            var vm = new NewSupplierDialogViewModel();
+            var vm = new NewSupplierDialogViewModel(_service);
             dialog.DataContext = vm;
             vm.CloseRequested += result => dialog.DialogResult = result;
             var result = dialog.ShowDialog();

--- a/Startup/NewUnitDialogService.cs
+++ b/Startup/NewUnitDialogService.cs
@@ -7,10 +7,17 @@ namespace Facturon.App
 {
     public class NewUnitDialogService : INewEntityDialogService<Unit>
     {
+        private readonly IUnitService _service;
+
+        public NewUnitDialogService(IUnitService service)
+        {
+            _service = service;
+        }
+
         public Unit? ShowDialog()
         {
             var dialog = new NewUnitDialog();
-            var vm = new NewUnitDialogViewModel();
+            var vm = new NewUnitDialogViewModel(_service);
             dialog.DataContext = vm;
             vm.CloseRequested += u => dialog.DialogResult = u != null;
             var result = dialog.ShowDialog();

--- a/Tests/ViewModels/NewSupplierDialogViewModelTests.cs
+++ b/Tests/ViewModels/NewSupplierDialogViewModelTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Facturon.App.ViewModels;
+using Facturon.Domain.Entities;
+using Facturon.Services;
+using Moq;
+using Xunit;
+
+namespace Facturon.Tests.ViewModels
+{
+    public class NewSupplierDialogViewModelTests
+    {
+        private static NewSupplierDialogViewModel CreateVm(IEnumerable<Supplier>? existing = null)
+        {
+            var service = new Mock<ISupplierService>();
+            service.Setup(s => s.GetAllAsync())
+                   .ReturnsAsync(existing != null ? new List<Supplier>(existing) : new List<Supplier>());
+            return new NewSupplierDialogViewModel(service.Object);
+        }
+
+        [Fact]
+        public void Name_Empty_ReturnsRequired()
+        {
+            var vm = CreateVm();
+            vm.Name = "";
+            Assert.Equal("Required", vm[nameof(NewSupplierDialogViewModel.Name)]);
+        }
+
+        [Fact]
+        public void Name_Duplicate_ReturnsExists()
+        {
+            var existing = new Supplier { Name = "Dup", TaxNumber = "1", Address = "A" };
+            var vm = CreateVm(new[] { existing });
+            vm.Name = "Dup";
+            Assert.Equal("Name exists", vm[nameof(NewSupplierDialogViewModel.Name)]);
+        }
+    }
+}

--- a/Tests/ViewModels/NewUnitDialogViewModelTests.cs
+++ b/Tests/ViewModels/NewUnitDialogViewModelTests.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Facturon.App.ViewModels.Dialogs;
+using Facturon.Domain.Entities;
+using Facturon.Services;
+using Moq;
+using Xunit;
+
+namespace Facturon.Tests.ViewModels
+{
+    public class NewUnitDialogViewModelTests
+    {
+        private static NewUnitDialogViewModel CreateVm(IEnumerable<Unit>? existing = null)
+        {
+            var service = new Mock<IUnitService>();
+            service.Setup(s => s.GetAllAsync())
+                   .ReturnsAsync(existing != null ? new List<Unit>(existing) : new List<Unit>());
+            return new NewUnitDialogViewModel(service.Object);
+        }
+
+        [Fact]
+        public void ShortName_Duplicate_ReturnsExists()
+        {
+            var existing = new Unit { Name = "U", ShortName = "pcs" };
+            var vm = CreateVm(new[] { existing });
+            vm.ShortName = "pcs";
+            Assert.Equal("Code exists", vm[nameof(NewUnitDialogViewModel.ShortName)]);
+        }
+    }
+}

--- a/ViewModels/Dialogs/NewUnitDialogViewModel.cs
+++ b/ViewModels/Dialogs/NewUnitDialogViewModel.cs
@@ -1,15 +1,50 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using Facturon.Domain.Entities;
+using Facturon.Services;
 
 namespace Facturon.App.ViewModels.Dialogs
 {
-    public class NewUnitDialogViewModel : BaseViewModel
+    public class NewUnitDialogViewModel : BaseViewModel, IDataErrorInfo
     {
+        private readonly HashSet<string> _existingNames;
+        private readonly HashSet<string> _existingShortNames;
+
         public Unit Unit { get; } = new Unit
         {
             Name = string.Empty,
             ShortName = string.Empty
         };
+
+        public string Name
+        {
+            get => Unit.Name;
+            set
+            {
+                if (Unit.Name != value)
+                {
+                    Unit.Name = value;
+                    OnPropertyChanged();
+                    SaveCommand.RaiseCanExecuteChanged();
+                }
+            }
+        }
+
+        public string ShortName
+        {
+            get => Unit.ShortName;
+            set
+            {
+                if (Unit.ShortName != value)
+                {
+                    Unit.ShortName = value;
+                    OnPropertyChanged();
+                    SaveCommand.RaiseCanExecuteChanged();
+                }
+            }
+        }
 
         private bool _isActive = true;
         public bool IsActive
@@ -30,22 +65,45 @@ namespace Facturon.App.ViewModels.Dialogs
 
         public event Action<Unit?>? CloseRequested;
 
-        public NewUnitDialogViewModel()
+        public NewUnitDialogViewModel(IUnitService unitService)
         {
+            var all = unitService.GetAllAsync().Result;
+            _existingNames = all.Select(u => u.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            _existingShortNames = all.Select(u => u.ShortName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
             SaveCommand = new RelayCommand(Save, CanSave);
             CancelCommand = new RelayCommand(() => CloseRequested?.Invoke(null));
         }
 
         private bool CanSave()
         {
-            return !string.IsNullOrWhiteSpace(Unit.Name)
-                && !string.IsNullOrWhiteSpace(Unit.ShortName);
+            return string.IsNullOrEmpty(this[nameof(Name)])
+                   && string.IsNullOrEmpty(this[nameof(ShortName)]);
         }
 
         private void Save()
         {
             Unit.Active = IsActive;
             CloseRequested?.Invoke(Unit);
+        }
+
+        public string Error => string.Empty;
+
+        public string this[string columnName]
+        {
+            get
+            {
+                return columnName switch
+                {
+                    nameof(Name) => string.IsNullOrWhiteSpace(Name)
+                        ? "Required"
+                        : _existingNames.Contains(Name) ? "Name exists" : string.Empty,
+                    nameof(ShortName) => string.IsNullOrWhiteSpace(ShortName)
+                        ? "Required"
+                        : _existingShortNames.Contains(ShortName) ? "Code exists" : string.Empty,
+                    _ => string.Empty
+                };
+            }
         }
     }
 }

--- a/ViewModels/NewSupplierDialogViewModel.cs
+++ b/ViewModels/NewSupplierDialogViewModel.cs
@@ -1,26 +1,107 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using System.Windows.Input;
 using Facturon.Domain.Entities;
+using Facturon.Services;
 
 namespace Facturon.App.ViewModels
 {
-    public class NewSupplierDialogViewModel : BaseViewModel
+    public class NewSupplierDialogViewModel : BaseViewModel, IDataErrorInfo
     {
-        public Supplier Supplier { get; set; } = new()
+        private readonly HashSet<string> _existingNames;
+        private readonly HashSet<string> _existingTaxNumbers;
+
+        public Supplier Supplier { get; } = new()
         {
             Name = string.Empty,
             Address = string.Empty,
             TaxNumber = string.Empty
         };
 
+        public string Name
+        {
+            get => Supplier.Name;
+            set
+            {
+                if (Supplier.Name != value)
+                {
+                    Supplier.Name = value;
+                    OnPropertyChanged();
+                    ((RelayCommand)SaveCommand).RaiseCanExecuteChanged();
+                }
+            }
+        }
+
+        public string Address
+        {
+            get => Supplier.Address;
+            set
+            {
+                if (Supplier.Address != value)
+                {
+                    Supplier.Address = value;
+                    OnPropertyChanged();
+                    ((RelayCommand)SaveCommand).RaiseCanExecuteChanged();
+                }
+            }
+        }
+
+        public string TaxNumber
+        {
+            get => Supplier.TaxNumber;
+            set
+            {
+                if (Supplier.TaxNumber != value)
+                {
+                    Supplier.TaxNumber = value;
+                    OnPropertyChanged();
+                    ((RelayCommand)SaveCommand).RaiseCanExecuteChanged();
+                }
+            }
+        }
+
         public ICommand SaveCommand { get; }
         public ICommand CancelCommand { get; }
         public event Action<bool>? CloseRequested;
 
-        public NewSupplierDialogViewModel()
+        public NewSupplierDialogViewModel(ISupplierService supplierService)
         {
-            SaveCommand = new RelayCommand(() => CloseRequested?.Invoke(true));
+            var all = supplierService.GetAllAsync().Result;
+            _existingNames = all.Select(s => s.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            _existingTaxNumbers = all.Select(s => s.TaxNumber).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            SaveCommand = new RelayCommand(() => CloseRequested?.Invoke(true), CanSave);
             CancelCommand = new RelayCommand(() => CloseRequested?.Invoke(false));
+        }
+
+        private bool CanSave()
+        {
+            return string.IsNullOrEmpty(this[nameof(Name)])
+                   && string.IsNullOrEmpty(this[nameof(Address)])
+                   && string.IsNullOrEmpty(this[nameof(TaxNumber)]);
+        }
+
+        public string Error => string.Empty;
+
+        public string this[string columnName]
+        {
+            get
+            {
+                return columnName switch
+                {
+                    nameof(Name) => string.IsNullOrWhiteSpace(Name)
+                        ? "Required"
+                        : _existingNames.Contains(Name) ? "Name exists" : string.Empty,
+                    nameof(Address) => string.IsNullOrWhiteSpace(Address)
+                        ? "Required" : string.Empty,
+                    nameof(TaxNumber) => string.IsNullOrWhiteSpace(TaxNumber)
+                        ? "Required"
+                        : _existingTaxNumbers.Contains(TaxNumber) ? "Tax number exists" : string.Empty,
+                    _ => string.Empty
+                };
+            }
         }
     }
 }

--- a/Views/Dialogs/NewUnitDialog.xaml
+++ b/Views/Dialogs/NewUnitDialog.xaml
@@ -8,11 +8,11 @@
         FocusManager.FocusedElement="{Binding ElementName=NameBox}">
     <StackPanel Margin="10">
         <TextBlock Text="Name:"/>
-        <TextBox x:Name="NameBox" Width="200" Text="{Binding Unit.Name, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
-        <TextBlock Foreground="Red" Margin="0,2,0,0" Text="{Binding ElementName=NameBox, Path=(Validation.Errors)[0].ErrorContent}" />
+        <TextBox x:Name="NameBox" Width="200"
+                 Text="{Binding Name, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
         <TextBlock Text="Short Code:" Margin="0,5,0,0"/>
-        <TextBox x:Name="ShortNameBox" Width="100" Text="{Binding Unit.ShortName, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
-        <TextBlock Foreground="Red" Margin="0,2,0,0" Text="{Binding ElementName=ShortNameBox, Path=(Validation.Errors)[0].ErrorContent}" />
+        <TextBox x:Name="ShortNameBox" Width="100"
+                 Text="{Binding ShortName, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
         <CheckBox Content="Active" Margin="0,5,0,0" IsChecked="{Binding IsActive}" />
         <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Right">
             <Button Content="OK" Width="75" Margin="0,0,5,0" IsDefault="True" Command="{Binding SaveCommand}" />

--- a/Views/NewSupplierDialog.xaml
+++ b/Views/NewSupplierDialog.xaml
@@ -8,11 +8,14 @@
         FocusManager.FocusedElement="{Binding ElementName=NameBox}">
     <StackPanel Margin="10">
         <TextBlock Text="Name:"/>
-        <TextBox x:Name="NameBox" Width="200" Text="{Binding Supplier.Name, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox x:Name="NameBox" Width="200"
+                 Text="{Binding Name, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
         <TextBlock Text="Address:" Margin="0,5,0,0"/>
-        <TextBox Width="200" Text="{Binding Supplier.Address, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Width="200"
+                 Text="{Binding Address, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
         <TextBlock Text="Tax Number:" Margin="0,5,0,0"/>
-        <TextBox Width="200" Text="{Binding Supplier.TaxNumber, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Width="200"
+                 Text="{Binding TaxNumber, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
         <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Right">
             <Button Content="Save" Width="75" Margin="0,0,5,0" IsDefault="True" Command="{Binding SaveCommand}" />
             <Button Content="Cancel" Width="75" IsCancel="True" Command="{Binding CancelCommand}" />


### PR DESCRIPTION
## Summary
- implement IDataErrorInfo on NewSupplierDialogViewModel and NewUnitDialogViewModel
- check for empty and duplicate values using services
- update dialogs to bind to new properties with LightTheme validation
- inject services into dialog services
- add tests covering validation messages
- log prompt entries

## Testing
- `dotnet test --no-build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688334a1a5d88322b38f89e7619701f2