### PR TITLE
Fix XAML EventTrigger prefix

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -327,3 +327,5 @@ namespaces in views and switched actions to the `ei` prefix to resolve
 `Interaction.Triggers` compile errors.
 ## [ui_agent] Restore XAML behaviors namespace
 Reverted views to use `http://schemas.microsoft.com/xaml/behaviors` for all triggers and actions after build errors.
+## [ui_agent] Prefix EventTriggers
+Replaced `EventTrigger` tags with `i:EventTrigger` in view files to fix "EventName does not exist" build errors.

--- a/Views/ConfirmExitWindow.xaml
+++ b/Views/ConfirmExitWindow.xaml
@@ -23,16 +23,16 @@
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <Button x:Name="YesButton" Content="Yes" Margin="0,0,5,0" Width="75">
             <i:Interaction.Triggers>
-                <EventTrigger EventName="Click">
+                <i:EventTrigger EventName="Click">
                     <i:InvokeCommandAction Command="{Binding CloseCommand}" CommandParameter="True" />
-                </EventTrigger>
+                </i:EventTrigger>
             </i:Interaction.Triggers>
             </Button>
             <Button x:Name="NoButton" Content="No" IsDefault="True" IsCancel="True" Width="75">
             <i:Interaction.Triggers>
-                <EventTrigger EventName="Click">
+                <i:EventTrigger EventName="Click">
                     <i:InvokeCommandAction Command="{Binding CloseCommand}" CommandParameter="False" />
-                </EventTrigger>
+                </i:EventTrigger>
             </i:Interaction.Triggers>
             </Button>
         </StackPanel>

--- a/Views/EditableComboWithAdd.xaml
+++ b/Views/EditableComboWithAdd.xaml
@@ -11,9 +11,9 @@
                   SelectedItem="{Binding SelectedItem}"
                     DisplayMemberPath="{Binding DisplayMemberPath, RelativeSource={RelativeSource AncestorType=UserControl}}">
             <i:Interaction.Triggers>
-                <EventTrigger EventName="LostFocus">
+                <i:EventTrigger EventName="LostFocus">
                     <i:InvokeCommandAction Command="{Binding ConfirmInputCommand}" />
-                </EventTrigger>
+                </i:EventTrigger>
             </i:Interaction.Triggers>
             <ComboBox.InputBindings>
                 <KeyBinding Key="Enter" Command="{Binding ConfirmInputCommand}" />

--- a/Views/InvoiceDetailView.xaml
+++ b/Views/InvoiceDetailView.xaml
@@ -7,9 +7,9 @@
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d">
     <i:Interaction.Triggers>
-        <EventTrigger EventName="Loaded">
+        <i:EventTrigger EventName="Loaded">
             <i:InvokeCommandAction Command="{Binding LoadCommand}" />
-        </EventTrigger>
+        </i:EventTrigger>
     </i:Interaction.Triggers>
     <Grid Margin="10">
         <Grid.RowDefinitions>

--- a/Views/InvoiceItemInputView.xaml
+++ b/Views/InvoiceItemInputView.xaml
@@ -4,9 +4,9 @@
              xmlns:views="clr-namespace:Facturon.App.Views"
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors">
     <i:Interaction.Triggers>
-        <EventTrigger EventName="Loaded">
+        <i:EventTrigger EventName="Loaded">
             <i:InvokeCommandAction Command="{Binding LoadCommand}" />
-        </EventTrigger>
+        </i:EventTrigger>
         <i:EventTrigger SourceObject="{Binding}" EventName="FocusRequested">
             <i:CallMethodAction TargetObject="{Binding ElementName=ProductCombo}" MethodName="FocusInput" />
         </i:EventTrigger>

--- a/Views/InvoiceListView.xaml
+++ b/Views/InvoiceListView.xaml
@@ -8,9 +8,9 @@
              FocusManager.FocusedElement="{Binding ElementName=InvoiceList}"
              >
     <i:Interaction.Triggers>
-        <EventTrigger EventName="Loaded">
+        <i:EventTrigger EventName="Loaded">
             <i:InvokeCommandAction Command="{Binding LoadedCommand}" />
-        </EventTrigger>
+        </i:EventTrigger>
     </i:Interaction.Triggers>
     <Grid>
         <ListBox x:Name="InvoiceList"

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -9,9 +9,9 @@
         Width="800"
         >
     <i:Interaction.Triggers>
-        <EventTrigger EventName="Loaded">
+        <i:EventTrigger EventName="Loaded">
             <i:InvokeCommandAction Command="{Binding LoadedCommand}" />
-        </EventTrigger>
+        </i:EventTrigger>
     </i:Interaction.Triggers>
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />

--- a/Views/NewProductDialog.xaml
+++ b/Views/NewProductDialog.xaml
@@ -13,9 +13,9 @@
         <KeyBinding Modifiers="Shift" Key="Enter" Command="{Binding MovePreviousCommand}" />
     </Window.InputBindings>
     <i:Interaction.Triggers>
-        <EventTrigger EventName="Loaded">
+        <i:EventTrigger EventName="Loaded">
             <i:InvokeCommandAction Command="{Binding LoadCommand}" />
-        </EventTrigger>
+        </i:EventTrigger>
     </i:Interaction.Triggers>
     <StackPanel Margin="10">
         <TextBlock Text="Name:"/>


### PR DESCRIPTION
## Summary
- fix build errors by prefixing EventTrigger tags with `i:`
- document the change in `PROMPT_LOG.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68840600bdec8322b760c9fac8e468a4