### PR TITLE
Fix generic constraint for entity dialog

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -329,3 +329,6 @@ namespaces in views and switched actions to the `ei` prefix to resolve
 Reverted views to use `http://schemas.microsoft.com/xaml/behaviors` for all triggers and actions after build errors.
 ## [ui_agent] Prefix EventTriggers
 Replaced `EventTrigger` tags with `i:EventTrigger` in view files to fix "EventName does not exist" build errors.
+
+## [ui_agent] Constrain EntityCreateDialogViewModel
+Added BaseEntity generic constraint and using directive in EntityCreateDialogViewModel to satisfy IEntityService requirement.

--- a/ViewModels/EntityCreateDialogViewModel.cs
+++ b/ViewModels/EntityCreateDialogViewModel.cs
@@ -1,7 +1,9 @@
 using Facturon.Services;
+using Facturon.Domain.Entities;
+
 namespace Facturon.App.ViewModels
 {
-    public class EntityCreateDialogViewModel<T> : BaseViewModel
+    public class EntityCreateDialogViewModel<T> : BaseViewModel where T : BaseEntity
     {
         private readonly IEntityService<T> _service;
 


### PR DESCRIPTION
## Summary
- enforce BaseEntity constraint in `EntityCreateDialogViewModel<T>` so it works with `IEntityService<T>`
- log the change in PROMPT_LOG

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68840753b0ac83228fb0fd40ec1cbe05