### PR TITLE
Fix build errors in ViewModels

### DIFF
--- a/PROMPT_LOG.md
+++ b/PROMPT_LOG.md
@@ -332,3 +332,7 @@ Replaced `EventTrigger` tags with `i:EventTrigger` in view files to fix "EventNa
 
 ## [ui_agent] Constrain EntityCreateDialogViewModel
 Added BaseEntity generic constraint and using directive in EntityCreateDialogViewModel to satisfy IEntityService requirement.
+## [ui_agent] Fix build errors for selectors
+Corrected generic type reference in InvoiceItemInputViewModel.
+Added LINQ using directive in TaxRateSelectorViewModel.
+Injected ISelectionHistoryService into MainViewModel and forwarded to InvoiceDetailViewModel.

--- a/ViewModels/InvoiceItemInputViewModel.cs
+++ b/ViewModels/InvoiceItemInputViewModel.cs
@@ -122,7 +122,7 @@ namespace Facturon.App.ViewModels
 
         private void SelectorOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(EditableComboWithAddViewModel<object>.SelectedItem))
+            if (e.PropertyName == nameof(EditableComboWithAddViewModel<BaseEntity>.SelectedItem))
                 AddCommand.RaiseCanExecuteChanged();
         }
 

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -23,6 +23,7 @@ namespace Facturon.App.ViewModels
         private readonly INewEntityDialogService<Supplier> _supplierDialogService;
         private readonly IInvoiceItemService _invoiceItemService;
         private readonly INavigationService _navigationService;
+        private readonly ISelectionHistoryService _historyService;
 
         public InvoiceListViewModel InvoiceList { get; }
         public InvoiceDetailViewModel InvoiceDetail { get; }
@@ -87,7 +88,8 @@ namespace Facturon.App.ViewModels
             INewEntityDialogService<Product> productDialogService,
             INewEntityDialogService<Unit> unitDialogService,
             INewEntityDialogService<TaxRate> taxDialogService,
-            INewEntityDialogService<Supplier> supplierDialogService)
+            INewEntityDialogService<Supplier> supplierDialogService,
+            ISelectionHistoryService historyService)
         {
             Debug.WriteLine("MainViewModel created");
             _invoiceService = invoiceService;
@@ -99,6 +101,7 @@ namespace Facturon.App.ViewModels
             _invoiceItemService = invoiceItemService;
             _confirmationService = confirmationService;
             _navigationService = navigationService;
+            _historyService = historyService;
             _paymentMethodDialogService = paymentMethodDialogService;
             _productDialogService = productDialogService;
             _unitDialogService = unitDialogService;
@@ -126,7 +129,8 @@ namespace Facturon.App.ViewModels
                 _taxDialogService,
                 _supplierDialogService,
                 _navigationService,
-                this);
+                this,
+                _historyService);
             StatusBar = new StatusBarViewModel();
 
             OpenInvoiceCommand = new RelayCommand(OpenSelected, () => ScreenState == InvoiceScreenState.Browsing && CanOpenSelected());

--- a/ViewModels/TaxRateSelectorViewModel.cs
+++ b/ViewModels/TaxRateSelectorViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Facturon.Domain.Entities;
 using Facturon.Services;


### PR DESCRIPTION
## Summary
- correct SelectedItem property check in InvoiceItemInputViewModel
- include LINQ extension support in TaxRateSelectorViewModel
- inject selection history into MainViewModel and pass it to InvoiceDetailViewModel
- log prompt

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68840c7f7be48322b6d431c28a29b2c8