### PR TITLE
Fix FocusRequested event signatures

### DIFF
--- a/Tests/ViewModels/InvoiceItemInputViewModelTests.cs
+++ b/Tests/ViewModels/InvoiceItemInputViewModelTests.cs
@@ -42,7 +42,7 @@ namespace Facturon.Tests.ViewModels
             vm.NetUnitPrice = 10m;
 
             var raised = false;
-            vm.FocusRequested += () => raised = true;
+            vm.FocusRequested += (_, __) => raised = true;
             vm.AddCommand.Execute(null);
 
             Assert.True(raised);

--- a/ViewModels/EditableComboWithAddViewModel.cs
+++ b/ViewModels/EditableComboWithAddViewModel.cs
@@ -16,7 +16,7 @@ namespace Facturon.App.ViewModels
         private readonly INewEntityDialogService<T> _dialogService;
         private readonly ISelectionHistoryService _historyService;
 
-        public event Action? FocusRequested;
+        public event EventHandler? FocusRequested;
 
         public RelayCommand ConfirmInputCommand { get; }
         public RelayCommand AddNewCommand { get; }
@@ -114,14 +114,14 @@ namespace Facturon.App.ViewModels
             var confirm = await _confirmationService.ConfirmAsync("Új elem?", $"A(z) '{Input}' nem található. Létrehozza?");
             if (!confirm)
             {
-                FocusRequested?.Invoke();
+                FocusRequested?.Invoke(this, EventArgs.Empty);
                 return;
             }
 
             var newEntity = _dialogService.ShowDialog();
             if (newEntity == null)
             {
-                FocusRequested?.Invoke();
+                FocusRequested?.Invoke(this, EventArgs.Empty);
                 return;
             }
 
@@ -134,7 +134,7 @@ namespace Facturon.App.ViewModels
             }
             else
             {
-                FocusRequested?.Invoke();
+                FocusRequested?.Invoke(this, EventArgs.Empty);
             }
         }
 
@@ -143,7 +143,7 @@ namespace Facturon.App.ViewModels
             var newEntity = _dialogService.ShowDialog();
             if (newEntity == null)
             {
-                FocusRequested?.Invoke();
+                FocusRequested?.Invoke(this, EventArgs.Empty);
                 return;
             }
 
@@ -156,7 +156,7 @@ namespace Facturon.App.ViewModels
             }
             else
             {
-                FocusRequested?.Invoke();
+                FocusRequested?.Invoke(this, EventArgs.Empty);
             }
         }
     }

--- a/ViewModels/InvoiceItemInputViewModel.cs
+++ b/ViewModels/InvoiceItemInputViewModel.cs
@@ -59,7 +59,7 @@ namespace Facturon.App.ViewModels
         public RelayCommand MovePreviousCommand { get; }
 
         public event Action<InvoiceItem>? ItemReadyToAdd;
-        public event Action? FocusRequested;
+        public event EventHandler? FocusRequested;
 
         public InvoiceItemViewModel? EditingItem { get; private set; }
         private bool _isEditing;
@@ -160,7 +160,7 @@ namespace Facturon.App.ViewModels
 
             ItemReadyToAdd?.Invoke(item);
             Clear();
-            FocusRequested?.Invoke();
+            FocusRequested?.Invoke(this, EventArgs.Empty);
         }
 
         private void Clear()
@@ -235,7 +235,7 @@ namespace Facturon.App.ViewModels
             EditingItem = null;
             IsEditing = false;
             Clear();
-            FocusRequested?.Invoke();
+            FocusRequested?.Invoke(this, EventArgs.Empty);
         }
     }
 }


### PR DESCRIPTION
## Summary
- use EventHandler signature for FocusRequested events
- adjust invocations in view models
- update related unit test

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68840e59faf88322834a1029dd8d7db3